### PR TITLE
Nba basketball reference advanced box score stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Refactored `getBasicBoxScoreStats` and `GetMatchups` to use `networkHeaders` and `DocumentRetriever`
+### Added
+- `NBAAdvBoxScoreStats` data model for basketball-reference NBA Advanced box score stats 
+
 ## [0.1.0-alpha] - 2025-02-25
 ### Added
 - Functionality to scrape NBA matchup and related basic box score stats data from https://basketball-reference.com (#2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
 - Refactored `getBasicBoxScoreStats` and `GetMatchups` to use `networkHeaders` and `DocumentRetriever`
 ## [0.1.0-alpha] - 2025-02-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+- Refactored `getBasicBoxScoreStats` and `GetMatchups` to use `networkHeaders` and `DocumentRetriever`
 ## [0.1.0-alpha] - 2025-02-25
 ### Added
 - Functionality to scrape NBA matchup and related basic box score stats data from https://basketball-reference.com (#2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Logging is more concise for `getBasicBoxScoreStats`
 - Slight refactor of `getBasicBoxScoreStats` to use shared components
 ### Added
-- `NBAAdvBoxScoreStats` data model for basketball-reference.com NBA Advanced box score stats
+- Added `GetAdvBoxScoreStats` to scrape NBA advanced box score stats from basketball-reference.com
+- `NBAAdvBoxScoreStats` is the data model for NBA Advanced box score stats from basketball-reference.com 
 - Created shared.go for shared components for scraping NBA box score data from basketball-reference.com
 - Created functions to extract player ID and transform player minutes played
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Refactored `getBasicBoxScoreStats` and `GetMatchups` to use `networkHeaders` and `DocumentRetriever`
+- Logging is more concise for `getBasicBoxScoreStats`
+- Slight refactor of `getBasicBoxScoreStats` to use shared components
 ### Added
-- `NBAAdvBoxScoreStats` data model for basketball-reference NBA Advanced box score stats
+- `NBAAdvBoxScoreStats` data model for basketball-reference.com NBA Advanced box score stats
+- Created shared.go for shared components for scraping NBA box score data from basketball-reference.com
+- Created functions to extract player ID and transform player minutes played
 
 ## [0.1.0-alpha] - 2025-02-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Refactored `getBasicBoxScoreStats` and `GetMatchups` to use `networkHeaders` and `DocumentRetriever`
 ### Added
-- `NBAAdvBoxScoreStats` data model for basketball-reference NBA Advanced box score stats 
+- `NBAAdvBoxScoreStats` data model for basketball-reference NBA Advanced box score stats
 
 ## [0.1.0-alpha] - 2025-02-25
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Slight refactor of `getBasicBoxScoreStats` to use shared components
 ### Added
 - Added `GetAdvBoxScoreStats` to scrape NBA advanced box score stats from basketball-reference.com
-- `NBAAdvBoxScoreStats` is the data model for NBA Advanced box score stats from basketball-reference.com 
+- `NBAAdvBoxScoreStats` is the data model for NBA Advanced box score stats from basketball-reference.com
 - Created shared.go for shared components for scraping NBA box score data from basketball-reference.com
 - Created functions to extract player ID and transform player minutes played
 

--- a/dataprovider/basketballreference/nba/adv_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/adv_box_score_stats.go
@@ -1,0 +1,319 @@
+package nba
+
+import (
+	"fmt"
+	"log"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference/nba/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	"github.com/lightning-dabbler/sportscrape/util/request"
+)
+
+const (
+	// Selector for Advanced Box Score stats tables
+	advBoxScoreSelector = `table[id$='game-advanced']`
+)
+
+// advBoxScoreStarterHeaderValues represents the headers in sequential order for the starter team members
+var advBoxScoreStarterHeaderValues headerValues = headerValues{
+	"Starters": struct{}{},
+	"MP":       struct{}{},
+	"TS%":      struct{}{},
+	"eFG%":     struct{}{},
+	"3PAr":     struct{}{},
+	"FTr":      struct{}{},
+	"ORB%":     struct{}{},
+	"DRB%":     struct{}{},
+	"TRB%":     struct{}{},
+	"AST%":     struct{}{},
+	"STL%":     struct{}{},
+	"BLK%":     struct{}{},
+	"TOV%":     struct{}{},
+	"USG%":     struct{}{},
+	"ORtg":     struct{}{},
+	"DRtg":     struct{}{},
+	"BPM":      struct{}{},
+}
+
+// advBoxScoreReservesHeaderValues represents the headers in sequential order for the reserve team members
+var advBoxScoreReservesHeaderValues headerValues = headerValues{
+	"Reserves": struct{}{},
+	"MP":       struct{}{},
+	"TS%":      struct{}{},
+	"eFG%":     struct{}{},
+	"3PAr":     struct{}{},
+	"FTr":      struct{}{},
+	"ORB%":     struct{}{},
+	"DRB%":     struct{}{},
+	"TRB%":     struct{}{},
+	"AST%":     struct{}{},
+	"STL%":     struct{}{},
+	"BLK%":     struct{}{},
+	"TOV%":     struct{}{},
+	"USG%":     struct{}{},
+	"ORtg":     struct{}{},
+	"DRtg":     struct{}{},
+	"BPM":      struct{}{},
+}
+
+// getAdvBoxScoreStats accepts an interface that represents model.NBAMatchup
+// It fetches the advanced box score stats associated with that matchup
+// Returns an array of model.NBAAdvBoxScoreStats in the form of interface{}
+func getAdvBoxScoreStats(nbaMatchup interface{}) []interface{} {
+	matchup := nbaMatchup.(model.NBAMatchup)
+	url := matchup.BoxScoreLink
+	PullTimestamp := time.Now().UTC()
+	start := time.Now().UTC()
+	var advNBABoxScoreStats []interface{}
+	fmt.Println("Scraping Advanced Box Score: " + url)
+	dr := request.NewDocumentRetriever(2 * time.Minute)
+	doc, err := dr.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	doc.Find(advBoxScoreSelector).Each(func(i int, s *goquery.Selection) {
+		var starterHeader string
+		var reserveHeader string
+		s.Find(boxScoreStarterHeaders).Each(func(_ int, s *goquery.Selection) {
+
+			starterHeader = util.CleanTextDatum(s.Text())
+			_, ok := advBoxScoreStarterHeaderValues[starterHeader]
+			if !ok {
+				log.Fatalf("%s is not a valid Starters Header @ %s\n", starterHeader, url)
+			}
+
+		})
+
+		s.Find(boxScoreStatsRecordsSelector).Each(func(j int, s *goquery.Selection) {
+			var boxScoreStats model.NBAAdvBoxScoreStats
+			if j < 5 || j > 5 {
+				boxScoreStats.PullTimestamp = PullTimestamp
+				boxScoreStats.EventID = matchup.EventID
+				if i == 0 {
+					boxScoreStats.Team = matchup.AwayTeam
+					boxScoreStats.Opponent = matchup.HomeTeam
+				} else {
+					boxScoreStats.Team = matchup.HomeTeam
+					boxScoreStats.Opponent = matchup.AwayTeam
+				}
+				boxScoreStats.EventDate = matchup.EventDate
+				if j < 5 {
+					boxScoreStats.Starter = true
+				} else {
+					boxScoreStats.Starter = false
+				}
+				boxScoreStats.PlayerLink = basketballreference.URL + util.CleanTextDatum(s.Find(boxScorePlayerLinkSelector).AttrOr("href", ""))
+				boxScoreStats.Player = util.CleanTextDatum(s.Find(boxScorePlayerSelector).Text())
+				playerID, err := extractPlayerID(boxScoreStats.PlayerLink)
+				if err != nil {
+					log.Fatalln(err)
+				}
+				boxScoreStats.PlayerID = playerID
+				minutesPlayed := util.CleanTextDatum(s.Find("td:nth-child(2)").Text())
+				if len(minutesPlayed) > 0 && unicode.IsDigit(rune(minutesPlayed[0])) {
+					totalMinutes, err := transformMinutesPlayed(minutesPlayed)
+					if err != nil {
+						log.Fatalln(err)
+					}
+
+					boxScoreStats.MinutesPlayed = totalMinutes
+					// TrueShootingPercentage
+					trueShootingPercentageText := util.CleanTextDatum(s.Find("td:nth-child(3)").Text())
+					trueShootingPercentage, err := util.TextToFloat32(trueShootingPercentageText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for trueShootingPercentageText to float32 - %w; defaulting to 0.", trueShootingPercentageText, err))
+						trueShootingPercentage = 0
+					}
+					boxScoreStats.TrueShootingPercentage = trueShootingPercentage
+
+					// EffectiveFieldGoalPercentage
+					effectiveFieldGoalPercentageText := util.CleanTextDatum(s.Find("td:nth-child(4)").Text())
+					effectiveFieldGoalPercentage, err := util.TextToFloat32(effectiveFieldGoalPercentageText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for effectiveFieldGoalPercentageText to float32 - %w; defaulting to 0.", effectiveFieldGoalPercentageText, err))
+						effectiveFieldGoalPercentage = 0
+					}
+					boxScoreStats.EffectiveFieldGoalPercentage = effectiveFieldGoalPercentage
+
+					// ThreePointAttemptRate
+					threePointAttemptRateText := util.CleanTextDatum(s.Find("td:nth-child(5)").Text())
+					threePointAttemptRate, err := util.TextToFloat32(threePointAttemptRateText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for threePointAttemptRateText to float32 - %w; defaulting to 0.", threePointAttemptRateText, err))
+						threePointAttemptRate = 0
+					}
+					boxScoreStats.ThreePointAttemptRate = threePointAttemptRate
+
+					// FreeThrowAttemptRate
+					freeThrowAttemptRateText := util.CleanTextDatum(s.Find("td:nth-child(6)").Text())
+					freeThrowAttemptRate, err := util.TextToFloat32(freeThrowAttemptRateText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for freeThrowAttemptRateText to float32 - %w; defaulting to 0.", freeThrowAttemptRateText, err))
+						freeThrowAttemptRate = 0
+					}
+					boxScoreStats.FreeThrowAttemptRate = freeThrowAttemptRate
+
+					// OffensiveReboundPercentage
+					offensiveReboundPercentageText := util.CleanTextDatum(s.Find("td:nth-child(7)").Text())
+					offensiveReboundPercentage, err := util.TextToFloat32(offensiveReboundPercentageText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for offensiveReboundPercentageText to float32 - %w; defaulting to 0.", offensiveReboundPercentageText, err))
+						offensiveReboundPercentage = 0
+					}
+					boxScoreStats.OffensiveReboundPercentage = offensiveReboundPercentage
+
+					// DefensiveReboundPercentage
+					defensiveReboundPercentageText := util.CleanTextDatum(s.Find("td:nth-child(8)").Text())
+					defensiveReboundPercentage, err := util.TextToFloat32(defensiveReboundPercentageText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for defensiveReboundPercentageText to float32 - %w; defaulting to 0.", defensiveReboundPercentageText, err))
+						defensiveReboundPercentage = 0
+					}
+					boxScoreStats.DefensiveReboundPercentage = defensiveReboundPercentage
+
+					// TotalReboundPercentage
+					totalReboundPercentageText := util.CleanTextDatum(s.Find("td:nth-child(9)").Text())
+					totalReboundPercentage, err := util.TextToFloat32(totalReboundPercentageText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for totalReboundPercentageText to float32 - %w; defaulting to 0.", totalReboundPercentageText, err))
+						totalReboundPercentage = 0
+					}
+					boxScoreStats.TotalReboundPercentage = totalReboundPercentage
+
+					// AssistPercentage
+					assistPercentageText := util.CleanTextDatum(s.Find("td:nth-child(10)").Text())
+					assistPercentage, err := util.TextToFloat32(assistPercentageText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for assistPercentageText to float32 - %w; defaulting to 0.", assistPercentageText, err))
+						assistPercentage = 0
+					}
+					boxScoreStats.AssistPercentage = assistPercentage
+
+					// StealPercentage
+					stealPercentageText := util.CleanTextDatum(s.Find("td:nth-child(11)").Text())
+					stealPercentage, err := util.TextToFloat32(stealPercentageText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for stealPercentageText to float32 - %w; defaulting to 0.", stealPercentageText, err))
+						stealPercentage = 0
+					}
+					boxScoreStats.StealPercentage = stealPercentage
+
+					// BlockPercentage
+					blockPercentageText := util.CleanTextDatum(s.Find("td:nth-child(12)").Text())
+					blockPercentage, err := util.TextToFloat32(blockPercentageText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for blockPercentageText to float32 - %w; defaulting to 0.", blockPercentageText, err))
+						blockPercentage = 0
+					}
+					boxScoreStats.BlockPercentage = blockPercentage
+
+					// TurnoverPercentage
+					turnoverPercentageText := util.CleanTextDatum(s.Find("td:nth-child(13)").Text())
+					turnoverPercentage, err := util.TextToFloat32(turnoverPercentageText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for turnoverPercentageText to float32 - %w; defaulting to 0.", turnoverPercentageText, err))
+						turnoverPercentage = 0
+					}
+					boxScoreStats.TurnoverPercentage = turnoverPercentage
+
+					// UsagePercentage
+					usagePercentageText := util.CleanTextDatum(s.Find("td:nth-child(14)").Text())
+					usagePercentage, err := util.TextToFloat32(usagePercentageText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for usagePercentageText to float32 - %w; defaulting to 0.", usagePercentageText, err))
+						usagePercentage = 0
+					}
+					boxScoreStats.UsagePercentage = usagePercentage
+
+					// OffensiveRating
+					offensiveRatingText := util.CleanTextDatum(s.Find("td:nth-child(15)").Text())
+					offensiveRating, err := util.TextToInt(offensiveRatingText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for offensiveRatingText to float32 - %w; defaulting to 0.", offensiveRatingText, err))
+						offensiveRating = 0
+					}
+					boxScoreStats.OffensiveRating = offensiveRating
+
+					// DefensiveRating
+					defensiveRatingText := util.CleanTextDatum(s.Find("td:nth-child(16)").Text())
+					defensiveRating, err := util.TextToInt(defensiveRatingText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for defensiveRatingText to float32 - %w; defaulting to 0.", defensiveRatingText, err))
+						defensiveRating = 0
+					}
+					boxScoreStats.DefensiveRating = defensiveRating
+
+					// BoxPlusMinus
+					boxPlusMinusText := util.CleanTextDatum(s.Find("td:nth-child(17)").Text())
+					boxPlusMinus, err := util.TextToFloat32(boxPlusMinusText)
+					if err != nil {
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for boxPlusMinusText to float32 - %w; defaulting to 0.", boxPlusMinusText, err))
+						boxPlusMinus = 0
+					}
+					boxScoreStats.BoxPlusMinus = boxPlusMinus
+
+				} else {
+					boxScoreStats.MinutesPlayed = 0
+				}
+
+				advNBABoxScoreStats = append(advNBABoxScoreStats, boxScoreStats)
+			} else {
+				s.Find(boxScoreReserveHeaders).Each(func(_ int, s *goquery.Selection) {
+
+					reserveHeader = util.CleanTextDatum(s.Text())
+					_, ok := advBoxScoreReservesHeaderValues[reserveHeader]
+					if !ok {
+						log.Fatalf("%s is not a valid Reserves Header @ %s\n", reserveHeader, url)
+					}
+				})
+			}
+		})
+	})
+	if len(advNBABoxScoreStats) == 0 {
+		fmt.Printf("No Data Scraped @ %s\n", url)
+	} else {
+		diff := time.Now().UTC().Sub(start)
+		fmt.Printf("Scraping of %s Completed in %s\n", url, diff)
+	}
+
+	return advNBABoxScoreStats
+}
+
+// advBoxScoreStatsWorker acts a worker for retrieving and constructing advanced box score stats
+func advBoxScoreStatsWorker(wg *sync.WaitGroup, workerNBAMatchups <-chan interface{}, boxScoreStats chan<- []interface{}) {
+	for matchup := range workerNBAMatchups {
+		boxScoreStats <- getAdvBoxScoreStats(matchup)
+		wg.Done()
+	}
+}
+
+// GetAdvBoxScoreStats retrieves all advanced box score stats for all matchups
+// It accepts a concurrency integer to parallelize the requests
+// Returns an array of model.NBAAdvBoxScoreStats in the form of interface{}
+func GetAdvBoxScoreStats(concurrency int, matchups ...interface{}) []interface{} {
+	var wg sync.WaitGroup
+	workerNBAMatchups := make(chan interface{}, concurrency)
+	BoxScoreStats := make(chan []interface{}, len(matchups))
+	for i := 0; i < cap(workerNBAMatchups); i++ {
+		go advBoxScoreStatsWorker(&wg, workerNBAMatchups, BoxScoreStats)
+	}
+	for _, matchup := range matchups {
+		wg.Add(1)
+		workerNBAMatchups <- matchup
+	}
+	wg.Wait()
+	close(workerNBAMatchups)
+	close(BoxScoreStats)
+
+	var allBoxScoreStats []interface{}
+	for boxScoreStats := range BoxScoreStats {
+		allBoxScoreStats = append(allBoxScoreStats, boxScoreStats...)
+
+	}
+	return allBoxScoreStats
+}

--- a/dataprovider/basketballreference/nba/adv_box_score_stats_test.go
+++ b/dataprovider/basketballreference/nba/adv_box_score_stats_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package nba
+
+import (
+	"testing"
+
+	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference/nba/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetAdvBoxScoreStats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	date := "2025-02-19"
+	matchups := GetMatchups(date)
+	advBoxScoreStats := GetAdvBoxScoreStats(1, matchups...)
+	numAwayPlayers := 0
+	numHomePlayers := 0
+	numAwayDNP := 0
+	numHomeDNP := 0
+	expectedNumAwayPlayers := 12
+	expectedNumHomePlayers := 15
+	expectedAwayDNP := 2
+	expectedHomeDNP := 5
+	for _, s := range advBoxScoreStats {
+		stats := s.(model.NBAAdvBoxScoreStats)
+		if stats.Team == "LA Lakers" {
+			// Actual home players
+			numHomePlayers += 1
+			if stats.MinutesPlayed == 0 {
+				// Actual home players that did not play
+				numHomeDNP += 1
+			}
+			// Sample player stats from home team (LeBron James)
+			if stats.Player == "LeBron James" {
+				assert.Equal(t, true, stats.Starter, "LeBron was a starter")
+				assert.Equal(t, "jamesle01", stats.PlayerID, "LeBron's player ID")
+				assert.Equal(t, "Charlotte", stats.Opponent, "LeBron's opposing team")
+				assert.Equal(t, "https://www.basketball-reference.com/players/j/jamesle01.html", stats.PlayerLink, "LeBron's player link")
+				assert.Equal(t, float32(37.9), stats.MinutesPlayed, "LeBron minutes played")
+				assert.Equal(t, float32(0.568), stats.TrueShootingPercentage, "LeBron true shooting percentage")
+				assert.Equal(t, float32(0.545), stats.EffectiveFieldGoalPercentage, "LeBron effective field goal percentage")
+				assert.Equal(t, float32(0.5), stats.ThreePointAttemptRate, "LeBron three point attempt rate")
+				assert.Equal(t, float32(0.091), stats.FreeThrowAttemptRate, "LeBron free throw attempt rate")
+				assert.Equal(t, float32(2.5), stats.OffensiveReboundPercentage, "LeBron offensive rebound percentage")
+				assert.Equal(t, float32(16.2), stats.DefensiveReboundPercentage, "LeBron defensive rebound percentage")
+				assert.Equal(t, float32(9.1), stats.TotalReboundPercentage, "LeBron total rebound percentage")
+				assert.Equal(t, float32(57.2), stats.AssistPercentage, "LeBron assist percentage")
+				assert.Equal(t, float32(1.2), stats.StealPercentage, "LeBron steal percentage")
+				assert.Equal(t, float32(6.7), stats.BlockPercentage, "LeBron block percentage")
+				assert.Equal(t, float32(8.0), stats.TurnoverPercentage, "LeBron turnover percentage")
+				assert.Equal(t, float32(27.8), stats.UsagePercentage, "LeBron usage percentage")
+				assert.Equal(t, 122, stats.OffensiveRating, "LeBron offensive rating")
+				assert.Equal(t, 97, stats.DefensiveRating, "LeBron defensive rating")
+				assert.Equal(t, float32(14.3), stats.BoxPlusMinus, "LeBron box plus minus")
+			}
+		} else {
+			// Actual away players
+			numAwayPlayers += 1
+			if stats.MinutesPlayed == 0 {
+				// Actual away players that did not play
+				numAwayDNP += 1
+			}
+			// Sample player stats from away team (Gabe Vincent)
+			if stats.Player == "Gabe Vincent" {
+				assert.Equal(t, false, stats.Starter, "Gabe was a reserve player")
+				assert.Equal(t, "vincega01", stats.PlayerID, "Gabe's player ID")
+				assert.Equal(t, "LA Lakers", stats.Opponent, "Gabe's opposing team")
+				assert.Equal(t, "https://www.basketball-reference.com/players/v/vincega01.html", stats.PlayerLink, "Gabe's player link")
+				assert.Equal(t, float32(20.2), stats.MinutesPlayed, "Gabe minutes played")
+				assert.Equal(t, float32(0.429), stats.TrueShootingPercentage, "Gabe true shooting percentage")
+				assert.Equal(t, float32(0.429), stats.EffectiveFieldGoalPercentage, "Gabe effective field goal percentage")
+				assert.Equal(t, float32(0.857), stats.ThreePointAttemptRate, "Gabe three point attempt rate")
+				assert.Equal(t, 0, stats.FreeThrowAttemptRate, "Gabe free throw attempt rate")
+				assert.Equal(t, float32(9.5), stats.OffensiveReboundPercentage, "Gabe offensive rebound percentage")
+				assert.Equal(t, float32(5.1), stats.DefensiveReboundPercentage, "Gabe defensive rebound percentage")
+				assert.Equal(t, float32(7.3), stats.TotalReboundPercentage, "Gabe total rebound percentage")
+				assert.Equal(t, float32(14.7), stats.AssistPercentage, "Gabe assist percentage")
+				assert.Equal(t, 0, stats.StealPercentage, "Gabe steal percentage")
+				assert.Equal(t, 0, stats.BlockPercentage, "Gabe block percentage")
+				assert.Equal(t, float32(12.5), stats.TurnoverPercentage, "Gabe turnover percentage")
+				assert.Equal(t, float32(16.8), stats.UsagePercentage, "Gabe usage percentage")
+				assert.Equal(t, 95, stats.OffensiveRating, "Gabe offensive rating")
+				assert.Equal(t, 107, stats.DefensiveRating, "Gabe defensive rating")
+				assert.Equal(t, float32(-6.0), stats.BoxPlusMinus, "Gabe box plus minus")
+			}
+		}
+
+	}
+	assert.Equal(t, expectedNumAwayPlayers, numAwayPlayers, "Assert number of away players on Charlotte")
+	assert.Equal(t, expectedNumHomePlayers, numHomePlayers, "Assert number of home players on LA Lakers")
+	assert.Equal(t, expectedAwayDNP, numAwayDNP, "Assert number of away players on Charlotte that did not play")
+	assert.Equal(t, expectedHomeDNP, numHomeDNP, "Assert number of home players on LA Lakers that did not play")
+}

--- a/dataprovider/basketballreference/nba/basic_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/basic_box_score_stats.go
@@ -134,13 +134,13 @@ func getBasicBoxScoreStats(nbaMatchup interface{}) []interface{} {
 					fieldGoalsMadeText := util.CleanTextDatum(s.Find("td:nth-child(3)").Text())
 					fieldGoalsMade, err := util.TextToInt(fieldGoalsMadeText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for fieldGoalsMadeText to Int - %w", fieldGoalsMadeText, err))
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for fieldGoalsMadeText to Int - %w; defaulting to 0.", fieldGoalsMadeText, err))
 						fieldGoalsMade = 0
 					}
 					fieldGoalAttemptsText := util.CleanTextDatum(s.Find("td:nth-child(4)").Text())
 					fieldGoalAttempts, err := util.TextToInt(fieldGoalAttemptsText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for fieldGoalAttemptsText to Int - %w", fieldGoalAttemptsText, err))
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for fieldGoalAttemptsText to Int - %w; defaulting to 0.", fieldGoalAttemptsText, err))
 						fieldGoalAttempts = 0
 					}
 					rawFieldGoalPercentage := util.CleanTextDatum(s.Find("td:nth-child(5)").Text())
@@ -158,13 +158,13 @@ func getBasicBoxScoreStats(nbaMatchup interface{}) []interface{} {
 					threePointsMadeText := util.CleanTextDatum(s.Find("td:nth-child(6)").Text())
 					threePointsMade, err := util.TextToInt(threePointsMadeText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for threePointsMadeText to Int - %w", threePointsMadeText, err))
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for threePointsMadeText to Int - %w; defaulting to 0.", threePointsMadeText, err))
 						threePointsMade = 0
 					}
 					threePointAttemptsText := util.CleanTextDatum(s.Find("td:nth-child(7)").Text())
 					threePointAttempts, err := util.TextToInt(threePointAttemptsText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for threePointAttemptsText to Int - %w", threePointAttemptsText, err))
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for threePointAttemptsText to Int - %w; defaulting to 0.", threePointAttemptsText, err))
 						threePointsMade = 0
 					}
 					rawthreePointPercentage := util.CleanTextDatum(s.Find("td:nth-child(8)").Text())
@@ -182,13 +182,13 @@ func getBasicBoxScoreStats(nbaMatchup interface{}) []interface{} {
 					freeThrowsMadeText := util.CleanTextDatum(s.Find("td:nth-child(9)").Text())
 					freeThrowsMade, err := util.TextToInt(freeThrowsMadeText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for freeThrowsMadeText to Int - %w", freeThrowsMadeText, err))
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for freeThrowsMadeText to Int - %w; defaulting to 0.", freeThrowsMadeText, err))
 						freeThrowsMade = 0
 					}
 					freeThrowAttemptsText := util.CleanTextDatum(s.Find("td:nth-child(10)").Text())
 					freeThrowAttempts, err := util.TextToInt(freeThrowAttemptsText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for freeThrowAttemptsText to Int - %w", freeThrowAttemptsText, err))
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for freeThrowAttemptsText to Int - %w; defaulting to 0.", freeThrowAttemptsText, err))
 						freeThrowAttempts = 0
 					}
 					rawfreeThrowPercentage := util.CleanTextDatum(s.Find("td:nth-child(11)").Text())
@@ -215,77 +215,77 @@ func getBasicBoxScoreStats(nbaMatchup interface{}) []interface{} {
 					OffensiveReboundsText := util.CleanTextDatum(s.Find("td:nth-child(12)").Text())
 					boxScoreStats.OffensiveRebounds, err = util.TextToInt(OffensiveReboundsText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for OffensiveReboundsText to Int - %w", OffensiveReboundsText, err))
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for OffensiveReboundsText to Int - %w; defaulting to 0.", OffensiveReboundsText, err))
 						boxScoreStats.OffensiveRebounds = 0
 					}
 
 					DefensiveReboundsText := util.CleanTextDatum(s.Find("td:nth-child(13)").Text())
 					boxScoreStats.DefensiveRebounds, err = util.TextToInt(DefensiveReboundsText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for DefensiveReboundsText to Int - %w", DefensiveReboundsText, err))
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for DefensiveReboundsText to Int - %w; defaulting to 0.", DefensiveReboundsText, err))
 						boxScoreStats.DefensiveRebounds = 0
 					}
 
 					TotalReboundsText := util.CleanTextDatum(s.Find("td:nth-child(14)").Text())
 					boxScoreStats.TotalRebounds, err = util.TextToInt(TotalReboundsText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for TotalReboundsText to Int - %w", TotalReboundsText, err))
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for TotalReboundsText to Int - %w; defaulting to 0.", TotalReboundsText, err))
 						boxScoreStats.TotalRebounds = 0
 					}
 
 					AssistsText := util.CleanTextDatum(s.Find("td:nth-child(15)").Text())
 					boxScoreStats.Assists, err = util.TextToInt(AssistsText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for AssistsText to Int - %w", AssistsText, err))
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for AssistsText to Int - %w; defaulting to 0.", AssistsText, err))
 						boxScoreStats.Assists = 0
 					}
 
 					StealsText := util.CleanTextDatum(s.Find("td:nth-child(16)").Text())
 					boxScoreStats.Steals, err = util.TextToInt(StealsText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for StealsText to Int - %w", StealsText, err))
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for StealsText to Int - %w; defaulting to 0.", StealsText, err))
 						boxScoreStats.Steals = 0
 					}
 
 					BlocksText := util.CleanTextDatum(s.Find("td:nth-child(17)").Text())
 					boxScoreStats.Blocks, err = util.TextToInt(BlocksText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for BlocksText to Int - %w", BlocksText, err))
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for BlocksText to Int - %w; defaulting to 0.", BlocksText, err))
 						boxScoreStats.Blocks = 0
 					}
 
 					TurnoversText := util.CleanTextDatum(s.Find("td:nth-child(18)").Text())
 					boxScoreStats.Turnovers, err = util.TextToInt(TurnoversText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for TurnoversText to In - %w", TurnoversText, err))
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for TurnoversText to In - %w; defaulting to 0.", TurnoversText, err))
 						boxScoreStats.Turnovers = 0
 					}
 
 					PersonalFoulsText := util.CleanTextDatum(s.Find("td:nth-child(19)").Text())
 					boxScoreStats.PersonalFouls, err = util.TextToInt(PersonalFoulsText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for PersonalFoulsText to Int - %w", PersonalFoulsText, err))
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for PersonalFoulsText to Int - %w; defaulting to 0.", PersonalFoulsText, err))
 						boxScoreStats.PersonalFouls = 0
 					}
 
 					PointsText := util.CleanTextDatum(s.Find("td:nth-child(20)").Text())
 					boxScoreStats.Points, err = util.TextToInt(PointsText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for PointsText to Int - %w", PointsText, err))
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for PointsText to Int - %w; defaulting to 0.", PointsText, err))
 						boxScoreStats.Points = 0
 					}
 
 					GameScoreText := util.CleanTextDatum(s.Find("td:nth-child(21)").Text())
 					boxScoreStats.GameScore, err = util.TextToFloat32(GameScoreText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for GameScoreText to Float64 - %w", GameScoreText, err))
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for GameScoreText to Float64 - %w; defaulting to 0.", GameScoreText, err))
 						boxScoreStats.GameScore = 0
 					}
 
 					PlusMinusText := util.CleanTextDatum(s.Find("td:nth-child(22)").Text())
 					boxScoreStats.PlusMinus, err = util.TextToInt(PlusMinusText)
 					if err != nil {
-						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for PlusMinusText to Int - %w", PlusMinusText, err))
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for PlusMinusText to Int - %w; defaulting to 0.", PlusMinusText, err))
 						boxScoreStats.PlusMinus = 0
 					}
 				} else {

--- a/dataprovider/basketballreference/nba/basic_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/basic_box_score_stats.go
@@ -3,7 +3,6 @@ package nba
 import (
 	"fmt"
 	"log"
-	"strings"
 	"sync"
 	"time"
 	"unicode"
@@ -17,17 +16,9 @@ import (
 )
 
 const (
-	// https://www.basketball-reference.com/boxscores/{event_id}.html Selectors for Box Scores
-	basicBoxScoreSelector             = `table[id$='game-basic']`
-	basicBoxScoreContentSelector      = `#content`
-	basicBoxScoreStatsRecordsSelector = `tbody > tr`
-	basicBoxScoreStarterHeaders       = `thead > tr:nth-child(2) th`
-	basicBoxScoreReserveHeaders       = `th`
-	basicBoxScorePlayerSelector       = "th"
-	basicBoxScorePlayerLinkSelector   = basicBoxScorePlayerSelector + " > a"
+	// Selector for Basic Box Score stats tables
+	basicBoxScoreSelector = `table[id$='game-basic']`
 )
-
-type headerValues map[string]struct{}
 
 // basicBoxScoreStarterHeaderValues represents the headers in sequential order for the starter team members
 var basicBoxScoreStarterHeaderValues headerValues = headerValues{
@@ -92,24 +83,22 @@ func getBasicBoxScoreStats(nbaMatchup interface{}) []interface{} {
 	var basicNBABoxScoreStats []interface{}
 	fmt.Println("Scraping Basic Box Score: " + url)
 	dr := request.NewDocumentRetriever(2 * time.Minute)
-	doc, err := dr.RetrieveDocument(url, networkHeaders, basicBoxScoreContentSelector)
+	doc, err := dr.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
 	if err != nil {
 		log.Fatalln(err)
 	}
 	doc.Find(basicBoxScoreSelector).Each(func(i int, s *goquery.Selection) {
 		var starterHeader string
 		var reserveHeader string
-		s.Find(basicBoxScoreStarterHeaders).Each(func(_ int, s *goquery.Selection) {
-
+		s.Find(boxScoreStarterHeaders).Each(func(_ int, s *goquery.Selection) {
 			starterHeader = util.CleanTextDatum(s.Text())
 			_, ok := basicBoxScoreStarterHeaderValues[starterHeader]
 			if !ok {
 				log.Fatalf("%s is not a valid Starters Header @ %s\n", starterHeader, url)
 			}
-
 		})
 
-		s.Find(basicBoxScoreStatsRecordsSelector).Each(func(j int, s *goquery.Selection) {
+		s.Find(boxScoreStatsRecordsSelector).Each(func(j int, s *goquery.Selection) {
 			var boxScoreStats model.NBABasicBoxScoreStats
 			if j < 5 || j > 5 {
 				boxScoreStats.PullTimestamp = PullTimestamp
@@ -127,106 +116,90 @@ func getBasicBoxScoreStats(nbaMatchup interface{}) []interface{} {
 				} else {
 					boxScoreStats.Starter = false
 				}
-				boxScoreStats.PlayerLink = basketballreference.URL + util.CleanTextDatum(s.Find(basicBoxScorePlayerLinkSelector).AttrOr("href", ""))
-				boxScoreStats.Player = util.CleanTextDatum(s.Find(basicBoxScorePlayerSelector).Text())
-				playerLinkSplit := strings.Split(boxScoreStats.PlayerLink, "/")
-				boxScoreStats.PlayerID = strings.Split(playerLinkSplit[len(playerLinkSplit)-1], ".")[0]
+				boxScoreStats.PlayerLink = basketballreference.URL + util.CleanTextDatum(s.Find(boxScorePlayerLinkSelector).AttrOr("href", ""))
+				boxScoreStats.Player = util.CleanTextDatum(s.Find(boxScorePlayerSelector).Text())
+				playerID, err := extractPlayerID(boxScoreStats.PlayerLink)
+				if err != nil {
+					log.Fatalln(err)
+				}
+				boxScoreStats.PlayerID = playerID
 				minutesPlayed := util.CleanTextDatum(s.Find("td:nth-child(2)").Text())
 				if len(minutesPlayed) > 0 && unicode.IsDigit(rune(minutesPlayed[0])) {
-					minutesPlayedSplit := strings.Split(minutesPlayed, ":")
-					minutes, err := util.TextToInt(minutesPlayedSplit[0])
+					totalMinutes, err := transformMinutesPlayed(minutesPlayed)
 					if err != nil {
-						log.Printf("Could not convert minutes %s to integer\n", minutesPlayedSplit[0])
 						log.Fatalln(err)
 					}
-
-					seconds, err := util.TextToInt(minutesPlayedSplit[1])
-					if err != nil {
-						log.Printf("Could not convert seconds %s to integer\n", minutesPlayedSplit[0])
-						log.Fatalln(err)
-					}
-
-					totalMinutes := float32(minutes) + (float32(seconds) / float32(60))
 					boxScoreStats.MinutesPlayed = totalMinutes
 
 					fieldGoalsMadeText := util.CleanTextDatum(s.Find("td:nth-child(3)").Text())
 					fieldGoalsMade, err := util.TextToInt(fieldGoalsMadeText)
 					if err != nil {
-						log.Printf("Can't convert '%s' for fieldGoalsMadeText to Int\n", fieldGoalsMadeText)
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for fieldGoalsMadeText to Int - %w", fieldGoalsMadeText, err))
 						fieldGoalsMade = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 					fieldGoalAttemptsText := util.CleanTextDatum(s.Find("td:nth-child(4)").Text())
 					fieldGoalAttempts, err := util.TextToInt(fieldGoalAttemptsText)
 					if err != nil {
-						log.Printf("Can't convert '%s' for fieldGoalAttemptsText to Int\n", fieldGoalAttemptsText)
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for fieldGoalAttemptsText to Int - %w", fieldGoalAttemptsText, err))
 						fieldGoalAttempts = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 					rawFieldGoalPercentage := util.CleanTextDatum(s.Find("td:nth-child(5)").Text())
 					var fieldGoalPercentage float32
 
 					if rawFieldGoalPercentage == "" {
-						fieldGoalPercentage = 0.00
+						fieldGoalPercentage = 0
 					} else {
 						fieldGoalPercentage, err = util.TextToFloat32(rawFieldGoalPercentage)
 						if err != nil {
-							log.Printf("Can't convert '%s' for rawFieldGoalPercentage to Float64\n", rawFieldGoalPercentage)
-							log.Fatalln(err)
+							log.Fatalln(fmt.Errorf("Can't convert '%s' for rawFieldGoalPercentage to Float64 - %w", rawFieldGoalPercentage, err))
 						}
 					}
 
 					threePointsMadeText := util.CleanTextDatum(s.Find("td:nth-child(6)").Text())
 					threePointsMade, err := util.TextToInt(threePointsMadeText)
 					if err != nil {
-						log.Printf("Can't convert '%s' for threePointsMadeText to Int\n", threePointsMadeText)
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for threePointsMadeText to Int - %w", threePointsMadeText, err))
 						threePointsMade = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 					threePointAttemptsText := util.CleanTextDatum(s.Find("td:nth-child(7)").Text())
 					threePointAttempts, err := util.TextToInt(threePointAttemptsText)
 					if err != nil {
-						log.Printf("Can't convert '%s' for threePointAttemptsText to Int\n", threePointAttemptsText)
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for threePointAttemptsText to Int - %w", threePointAttemptsText, err))
 						threePointsMade = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 					rawthreePointPercentage := util.CleanTextDatum(s.Find("td:nth-child(8)").Text())
 					var threePointPercentage float32
 
 					if rawthreePointPercentage == "" {
-						threePointPercentage = 0.00
+						threePointPercentage = 0
 					} else {
 						threePointPercentage, err = util.TextToFloat32(rawthreePointPercentage)
 						if err != nil {
-							log.Printf("Can't convert '%s' for rawthreePointPercentage to Float64\n", rawthreePointPercentage)
-							log.Fatalln(err)
+							log.Fatalln(fmt.Errorf("Can't convert '%s' for rawthreePointPercentage to Float64 - %w", rawthreePointPercentage, err))
 						}
 					}
 
 					freeThrowsMadeText := util.CleanTextDatum(s.Find("td:nth-child(9)").Text())
 					freeThrowsMade, err := util.TextToInt(freeThrowsMadeText)
 					if err != nil {
-						log.Printf("Can't convert '%s' for freeThrowsMadeText to Int\n", freeThrowsMadeText)
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for freeThrowsMadeText to Int - %w", freeThrowsMadeText, err))
 						freeThrowsMade = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 					freeThrowAttemptsText := util.CleanTextDatum(s.Find("td:nth-child(10)").Text())
 					freeThrowAttempts, err := util.TextToInt(freeThrowAttemptsText)
 					if err != nil {
-						log.Printf("Can't convert '%s' for freeThrowAttemptsText to Int\n", freeThrowAttemptsText)
+						log.Println(fmt.Errorf("WARNING: Can't convert '%s' for freeThrowAttemptsText to Int - %w", freeThrowAttemptsText, err))
 						freeThrowAttempts = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 					rawfreeThrowPercentage := util.CleanTextDatum(s.Find("td:nth-child(11)").Text())
 					var freeThrowPercentage float32
 
 					if rawfreeThrowPercentage == "" {
-						freeThrowPercentage = 0.00
+						freeThrowPercentage = 0
 					} else {
 						freeThrowPercentage, err = util.TextToFloat32(rawfreeThrowPercentage)
 						if err != nil {
-							log.Printf("Can't convert '%s' for rawfreeThrowPercentage to Float64\n", rawfreeThrowPercentage)
-							log.Fatalln(err)
+							log.Fatalln(fmt.Errorf("Error: Can't convert '%s' for rawfreeThrowPercentage to Float64 - %w", rawfreeThrowPercentage, err))
 						}
 					}
 					boxScoreStats.FieldGoalsMade = fieldGoalsMade
@@ -242,96 +215,85 @@ func getBasicBoxScoreStats(nbaMatchup interface{}) []interface{} {
 					OffensiveReboundsText := util.CleanTextDatum(s.Find("td:nth-child(12)").Text())
 					boxScoreStats.OffensiveRebounds, err = util.TextToInt(OffensiveReboundsText)
 					if err != nil {
-						log.Printf("Cannot convert '%s' for OffensiveReboundsText to Int\n", OffensiveReboundsText)
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for OffensiveReboundsText to Int - %w", OffensiveReboundsText, err))
 						boxScoreStats.OffensiveRebounds = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 
 					DefensiveReboundsText := util.CleanTextDatum(s.Find("td:nth-child(13)").Text())
 					boxScoreStats.DefensiveRebounds, err = util.TextToInt(DefensiveReboundsText)
 					if err != nil {
-						log.Printf("Cannot convert '%s' for DefensiveReboundsText to Int\n", DefensiveReboundsText)
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for DefensiveReboundsText to Int - %w", DefensiveReboundsText, err))
 						boxScoreStats.DefensiveRebounds = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 
 					TotalReboundsText := util.CleanTextDatum(s.Find("td:nth-child(14)").Text())
 					boxScoreStats.TotalRebounds, err = util.TextToInt(TotalReboundsText)
 					if err != nil {
-						log.Printf("Cannot convert '%s' for TotalReboundsText to Int\n", TotalReboundsText)
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for TotalReboundsText to Int - %w", TotalReboundsText, err))
 						boxScoreStats.TotalRebounds = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 
 					AssistsText := util.CleanTextDatum(s.Find("td:nth-child(15)").Text())
 					boxScoreStats.Assists, err = util.TextToInt(AssistsText)
 					if err != nil {
-						log.Printf("Cannot convert '%s' for AssistsText to Int\n", AssistsText)
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for AssistsText to Int - %w", AssistsText, err))
 						boxScoreStats.Assists = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 
 					StealsText := util.CleanTextDatum(s.Find("td:nth-child(16)").Text())
 					boxScoreStats.Steals, err = util.TextToInt(StealsText)
 					if err != nil {
-						log.Printf("Cannot convert '%s' for StealsText to Int\n", StealsText)
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for StealsText to Int - %w", StealsText, err))
 						boxScoreStats.Steals = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 
 					BlocksText := util.CleanTextDatum(s.Find("td:nth-child(17)").Text())
 					boxScoreStats.Blocks, err = util.TextToInt(BlocksText)
 					if err != nil {
-						log.Printf("Cannot convert '%s' for BlocksText to Int\n", BlocksText)
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for BlocksText to Int - %w", BlocksText, err))
 						boxScoreStats.Blocks = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 
 					TurnoversText := util.CleanTextDatum(s.Find("td:nth-child(18)").Text())
 					boxScoreStats.Turnovers, err = util.TextToInt(TurnoversText)
 					if err != nil {
-						log.Printf("Cannot convert '%s' for TurnoversText to Int\n", TurnoversText)
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for TurnoversText to In - %w", TurnoversText, err))
 						boxScoreStats.Turnovers = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 
 					PersonalFoulsText := util.CleanTextDatum(s.Find("td:nth-child(19)").Text())
 					boxScoreStats.PersonalFouls, err = util.TextToInt(PersonalFoulsText)
 					if err != nil {
-						log.Printf("Cannot convert '%s' for PersonalFoulsText to Int\n", PersonalFoulsText)
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for PersonalFoulsText to Int - %w", PersonalFoulsText, err))
 						boxScoreStats.PersonalFouls = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 
 					PointsText := util.CleanTextDatum(s.Find("td:nth-child(20)").Text())
 					boxScoreStats.Points, err = util.TextToInt(PointsText)
 					if err != nil {
-						log.Printf("Cannot convert '%s' for PointsText to Int\n", PointsText)
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for PointsText to Int - %w", PointsText, err))
 						boxScoreStats.Points = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 
 					GameScoreText := util.CleanTextDatum(s.Find("td:nth-child(21)").Text())
 					boxScoreStats.GameScore, err = util.TextToFloat32(GameScoreText)
 					if err != nil {
-						log.Printf("Cannot convert '%s' for GameScoreText to Float64\n", GameScoreText)
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for GameScoreText to Float64 - %w", GameScoreText, err))
 						boxScoreStats.GameScore = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 
 					PlusMinusText := util.CleanTextDatum(s.Find("td:nth-child(22)").Text())
 					boxScoreStats.PlusMinus, err = util.TextToInt(PlusMinusText)
 					if err != nil {
-						log.Printf("Cannot convert '%s' for PlusMinusText to Int\n", PlusMinusText)
+						log.Println(fmt.Errorf("WARNING: Cannot convert '%s' for PlusMinusText to Int - %w", PlusMinusText, err))
 						boxScoreStats.PlusMinus = 0
-						log.Printf("WARNING: %s\n", err.Error())
 					}
 				} else {
 					boxScoreStats.MinutesPlayed = 0
 				}
 				basicNBABoxScoreStats = append(basicNBABoxScoreStats, boxScoreStats)
 			} else {
-				s.Find(basicBoxScoreReserveHeaders).Each(func(_ int, s *goquery.Selection) {
+				s.Find(boxScoreReserveHeaders).Each(func(_ int, s *goquery.Selection) {
 
 					reserveHeader = util.CleanTextDatum(s.Text())
 					_, ok := basicBoxScoreReservesHeaderValues[reserveHeader]

--- a/dataprovider/basketballreference/nba/matchups.go
+++ b/dataprovider/basketballreference/nba/matchups.go
@@ -1,7 +1,6 @@
 package nba
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"strings"
@@ -9,13 +8,12 @@ import (
 	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference"
 	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference/nba/model"
 	"github.com/lightning-dabbler/sportscrape/util"
+	"github.com/lightning-dabbler/sportscrape/util/request"
 	sportsreferenceutil "github.com/lightning-dabbler/sportscrape/util/sportsreference"
 
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/chromedp/cdproto/network"
-	"github.com/chromedp/chromedp"
 )
 
 const (
@@ -57,44 +55,17 @@ func GetMatchups(date string) []interface{} {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	ctx, cancel := chromedp.NewContext(context.Background())
-	defer cancel()
-	ctx, cancel = context.WithTimeout(ctx, 60*time.Second)
-	defer cancel()
-	fmt.Println("Scraping Matchups: " + url)
-	var outer string
 	PullTimestamp := time.Now().UTC()
+	start := time.Now().UTC()
+	fmt.Println("Scraping Matchups: " + url)
+
 	EventDate, err := sportsreferenceutil.EventDate(date)
 	if err != nil {
 		log.Fatalln(err)
 	}
-	start := time.Now().UTC()
-	if err := chromedp.Run(ctx,
-		network.Enable(),
-		network.SetExtraHTTPHeaders(network.Headers(map[string]interface{}{
-			"authority":                 "www.basketball-reference.com",
-			"accept":                    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-			"accept-language":           "en-US;q=0.8",
-			"cookie":                    "is_live=true; sr_note_box_countdown=57",
-			"if-modified-since":         "Tue, 08 Nov 2022 01:08:31 GMT",
-			"sec-fetch-dest":            "document",
-			"sec-fetch-mode":            "navigate",
-			"sec-fetch-site":            "none",
-			"sec-fetch-user":            "?1",
-			"sec-gpc":                   "1",
-			"upgrade-insecure-requests": "1",
-			"user-agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.53 Safari/537.36",
-		})),
-		chromedp.Navigate(url),
-		chromedp.WaitReady(matchupsGameSummariesSelector),
-		chromedp.OuterHTML(matchupsGameSummariesSelector, &outer, chromedp.ByQuery),
-	); err != nil && strings.Trim(err.Error(), " ") != "context deadline exceeded" {
-		fmt.Println("ERROR:")
-		fmt.Printf("GetMatchups %s\n", url)
-		log.Fatalln(err)
-	}
-	myReader := strings.NewReader(outer)
-	doc, err := goquery.NewDocumentFromReader(myReader)
+	dr := request.NewDocumentRetriever(60 * time.Second)
+
+	doc, err := dr.RetrieveDocument(url, networkHeaders, matchupsGameSummariesSelector)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/dataprovider/basketballreference/nba/model/adv_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/model/adv_box_score_stats.go
@@ -1,0 +1,59 @@
+package model
+
+import (
+	"time"
+)
+
+// NBAAdvBoxScoreStats represents the data model for NBA advanced box score stats scraped from basketball-reference.com
+type NBAAdvBoxScoreStats struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// EventID is the event id of the matchup associated with the box score
+	EventID string `json:"event_id"`
+	// EventDate is the timestamp associated with a given event
+	EventDate time.Time `json:"event_date"`
+	// Team is the player's team name
+	Team string `json:"team"`
+	// Opponent is the opposing team name
+	Opponent string `json:"opponent"`
+	// PlayerID is the player's id extracted from the player's basketball-reference profile url
+	PlayerID string `json:"player_id"`
+	// Player is the player's name
+	Player string `json:"player"`
+	// PlayerLink is the link to the player's basketball-reference profile
+	PlayerLink string `json:"player_link"`
+	// Starter is whether the player was apart of the team's starting five during the event or not
+	Starter bool `json:"starter"`
+	// MinutesPlayed is minutes played during the event
+	MinutesPlayed float32 `json:"minutes_played"`
+	// TrueShootingPercentage - A measure of shooting efficiency that takes into account 2-point field goals, 3-point field goals, and free throws (in decimal notation).
+	TrueShootingPercentage float32 `json:"true_shooting_percentage"`
+	// EffectiveFieldGoalPercentage - This statistic adjusts for the fact that a 3-point field goal is worth one more point than a 2-point field goal (in decimal notation).
+	EffectiveFieldGoalPercentage float32 `json:"effective_field_goal_percentage"`
+	// ThreePointAttemptRate - Percentage of FG Attempts from 3-Point Range (in decimal notation).
+	ThreePointAttemptRate float32 `json:"three_point_attempt_rate"`
+	// FreeThrowAttemptRate - Number of FT Attempts Per FG Attempt (in decimal notation).
+	FreeThrowAttemptRate float32 `json:"free_throw_attempt_rate"`
+	// OffensiveReboundPercentage - An estimate of the percentage of available offensive rebounds a player grabbed while they were on the floor (in percent notation).
+	OffensiveReboundPercentage float32 `json:"offensive_rebound_percentage"`
+	// DefensiveReboundPercentage - An estimate of the percentage of available defensive rebounds a player grabbed while they were on the floor (in percent notation).
+	DefensiveReboundPercentage float32 `json:"defensive_rebound_percentage"`
+	// TotalReboundPercentage - An estimate of the percentage of available rebounds a player grabbed while they were on the floor (in percent notation).
+	TotalReboundPercentage float32 `json:"total_rebound_percentage"`
+	// AssistPercentage - An estimate of the percentage of teammate field goals a player assisted while they were on the floor (in percent notation).
+	AssistPercentage float32 `json:"assist_percentage"`
+	// StealPercentage - An estimate of the percentage of opponent possessions that end with a steal by the player while they were on the floor (in percent notation).
+	StealPercentage float32 `json:"steal_percentage"`
+	// BlockPercentage - An estimate of the percentage of opponent two-point field goal attempts blocked by the player while they were on the floor (in percent notation).
+	BlockPercentage float32 `json:"block_percentage"`
+	// TurnoverPercentage - An estimate of turnovers committed per 100 plays (in percent notation).
+	TurnoverPercentage float32 `json:"turnover_percentage"`
+	// UsagePercentage - An estimate of the percentage of team plays used by a player while they were on the floor (in percent notation).
+	UsagePercentage float32 `json:"usage_percentage"`
+	// OffensiveRating - An estimate of points produced (players) or scored (teams) per 100 possessions
+	OffensiveRating int `json:"offensive_rating"`
+	// DefensiveRating - An estimate of points allowed per 100 possessions
+	DefensiveRating int `json:"defensive_rating"`
+	// BoxPlusMinus - A box score estimate of the points per 100 possessions a player contributed above a league-average player, translated to an average team.
+	BoxPlusMinus float32 `json:"box_plus_minus"`
+}

--- a/dataprovider/basketballreference/nba/shared.go
+++ b/dataprovider/basketballreference/nba/shared.go
@@ -1,7 +1,11 @@
 package nba
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/chromedp/cdproto/network"
+	"github.com/lightning-dabbler/sportscrape/util"
 )
 
 var networkHeaders network.Headers = network.Headers(map[string]interface{}{
@@ -18,3 +22,41 @@ var networkHeaders network.Headers = network.Headers(map[string]interface{}{
 	"upgrade-insecure-requests": "1",
 	"user-agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.53 Safari/537.36",
 })
+
+type headerValues map[string]struct{}
+
+const (
+	// https://www.basketball-reference.com/boxscores/{event_id}.html
+	waitReadyBoxScoreContentSelector = `#content`
+	boxScoreStatsRecordsSelector     = `tbody > tr`
+	boxScoreStarterHeaders           = `thead > tr:nth-child(2) th`
+	boxScoreReserveHeaders           = `th`
+	boxScorePlayerSelector           = "th"
+	boxScorePlayerLinkSelector       = boxScorePlayerSelector + " > a"
+)
+
+// extractPlayerID extracts PlayerID from PlayerLink
+func extractPlayerID(playerLink string) (string, error) {
+	playerLinkSplit := strings.Split(playerLink, "/")
+	result := strings.Split(playerLinkSplit[len(playerLinkSplit)-1], ".")[0]
+	if result == "" {
+		return "", fmt.Errorf("Error: Player ID is an empty string when parsing %s", playerLink)
+	}
+	return result, nil
+}
+
+func transformMinutesPlayed(minutesPlayed string) (float32, error) {
+	minutesPlayedSplit := strings.Split(minutesPlayed, ":")
+	minutes, err := util.TextToInt(minutesPlayedSplit[0])
+	if err != nil {
+		return 0, fmt.Errorf("Could not convert minutes %s to integer: %w", minutesPlayedSplit[0], err)
+	}
+
+	seconds, err := util.TextToInt(minutesPlayedSplit[1])
+	if err != nil {
+		return 0, fmt.Errorf("Could not convert seconds %s to integer: %w", minutesPlayedSplit[1], err)
+	}
+
+	totalMinutes := float32(minutes) + (float32(seconds) / float32(60))
+	return totalMinutes, nil
+}

--- a/dataprovider/basketballreference/nba/shared.go
+++ b/dataprovider/basketballreference/nba/shared.go
@@ -1,0 +1,20 @@
+package nba
+
+import (
+	"github.com/chromedp/cdproto/network"
+)
+
+var networkHeaders network.Headers = network.Headers(map[string]interface{}{
+	"authority":                 "www.basketball-reference.com",
+	"accept":                    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+	"accept-language":           "en-US;q=0.8",
+	"cookie":                    "is_live=true; sr_note_box_countdown=57",
+	"if-modified-since":         "Tue, 08 Nov 2022 01:08:31 GMT",
+	"sec-fetch-dest":            "document",
+	"sec-fetch-mode":            "navigate",
+	"sec-fetch-site":            "none",
+	"sec-fetch-user":            "?1",
+	"sec-gpc":                   "1",
+	"upgrade-insecure-requests": "1",
+	"user-agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.53 Safari/537.36",
+})

--- a/dataprovider/basketballreference/nba/shared_test.go
+++ b/dataprovider/basketballreference/nba/shared_test.go
@@ -1,0 +1,94 @@
+//go:build unit
+
+package nba
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractPlayerID(t *testing.T) {
+	tests := []struct {
+		name        string
+		link        string
+		expectation string
+		isError     bool
+	}{
+		{
+			name:        "trae young player ID",
+			link:        "https://www.basketball-reference.com/players/y/youngtr01.html",
+			expectation: "youngtr01",
+		},
+		{
+			name:        "clint capela player ID",
+			link:        "https://www.basketball-reference.com/players/c/capelca01.html",
+			expectation: "capelca01",
+		},
+		{
+			name:        "cole anthony player ID",
+			link:        "https://www.basketball-reference.com/players/a/anthoco01.html",
+			expectation: "anthoco01",
+		},
+		{
+			name:    "Error empty string",
+			link:    "",
+			isError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := extractPlayerID(tt.link)
+			if tt.isError {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tt.expectation, actual, "Equal player id")
+			}
+		})
+	}
+}
+
+func TestTransformMinutesPlayed(t *testing.T) {
+	tests := []struct {
+		name        string
+		minutes     string
+		expectation float32
+		isError     bool
+	}{
+		{
+			name:        "valid conversion",
+			minutes:     "30:15",
+			expectation: float32(30.25),
+		},
+		{
+			name:    "invalid minutes (missing minutes)",
+			minutes: ":15",
+			isError: true,
+		},
+		{
+			name:    "invalid minutes (letter in minutes)",
+			minutes: "rt:15",
+			isError: true,
+		},
+		{
+			name:    "invalid seconds (letter in seconds)",
+			minutes: "20:t15",
+			isError: true,
+		},
+		{
+			name:    "invalid seconds (missing seconds)",
+			minutes: "20:",
+			isError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := transformMinutesPlayed(tt.minutes)
+			if tt.isError {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tt.expectation, actual, "Parsed minutes")
+			}
+		})
+	}
+}

--- a/util/request/request.go
+++ b/util/request/request.go
@@ -1,11 +1,19 @@
 package request
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/chromedp"
 )
 
-// Get performs a GET request using the url it receives
+// Get performs a GET request
 // Returns an http response
 func Get(url string) (*http.Response, error) {
 	fmt.Printf("Fetching from %s\n", url)
@@ -17,4 +25,48 @@ func Get(url string) (*http.Response, error) {
 		return nil, fmt.Errorf("Request to '%s' received a %s status", url, resp.Status)
 	}
 	return resp, nil
+}
+
+// DocumentRetriever
+type DocumentRetriever struct {
+	timeout        time.Duration
+	ChromeRun      func(ctx context.Context, actions ...chromedp.Action) error
+	DocumentReader func(r io.Reader) (*goquery.Document, error)
+}
+
+// NewDocumentRetriever accepts a timeout
+// returns DocumentRetriever
+func NewDocumentRetriever(timeout time.Duration) *DocumentRetriever {
+	return &DocumentRetriever{
+		timeout:        timeout,
+		ChromeRun:      chromedp.Run,
+		DocumentReader: goquery.NewDocumentFromReader,
+	}
+}
+
+// RetrieveDocument accepts a url, network headers, and selector to indicate when the page is ready
+// It uses chromium to fetch a web page from the url
+// Returns *goquery.Document and error
+func (dr *DocumentRetriever) RetrieveDocument(url string, networkHeaders network.Headers, waitReadySelector string) (*goquery.Document, error) {
+	ctx, cancel := chromedp.NewContext(context.Background())
+	defer cancel()
+	ctx, cancel = context.WithTimeout(ctx, dr.timeout)
+	defer cancel()
+	fmt.Println("Retrieving document from: " + url)
+	var outer string
+	if err := dr.ChromeRun(ctx,
+		network.Enable(),
+		network.SetExtraHTTPHeaders(networkHeaders),
+		chromedp.Navigate(url),
+		chromedp.WaitReady(waitReadySelector),
+		chromedp.OuterHTML(waitReadySelector, &outer, chromedp.ByQuery),
+	); err != nil {
+		return nil, fmt.Errorf("Error fetching document from %s: %w", url, err)
+	}
+	myReader := strings.NewReader(outer)
+	doc, err := dr.DocumentReader(myReader)
+	if err != nil {
+		return nil, fmt.Errorf("Error reading document from %s: %w", url, err)
+	}
+	return doc, nil
 }

--- a/util/request/request_test.go
+++ b/util/request/request_test.go
@@ -8,7 +8,16 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"context"
+	"errors"
+	"strings"
+	"time"
+
 	"github.com/stretchr/testify/assert"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/chromedp/cdproto/network"
+	"github.com/chromedp/chromedp"
 )
 
 func TestGetUnitTests(t *testing.T) {
@@ -94,4 +103,124 @@ func TestGetIntegrationTests(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewDocumentRetriever(t *testing.T) {
+	timeout := 30 * time.Second
+	dr := NewDocumentRetriever(timeout)
+
+	assert.Equal(t, timeout, dr.timeout)
+	assert.NotNil(t, dr.ChromeRun)
+	assert.NotNil(t, dr.DocumentReader)
+}
+
+func TestRetrieveDocument(t *testing.T) {
+	testCases := []struct {
+		name         string
+		runErr       error
+		docReaderErr error
+		expectErr    bool
+	}{
+		{
+			name:         "Success",
+			runErr:       nil,
+			docReaderErr: nil,
+			expectErr:    false,
+		},
+		{
+			name:         "ChromeRun error",
+			runErr:       errors.New("chrome error"),
+			docReaderErr: nil,
+			expectErr:    true,
+		},
+		{
+			name:         "DocumentReader error",
+			runErr:       nil,
+			docReaderErr: errors.New("doc reader error"),
+			expectErr:    true,
+		},
+		{
+			name:         "Context timeout",
+			runErr:       context.DeadlineExceeded,
+			docReaderErr: nil,
+			expectErr:    true,
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			dr := &DocumentRetriever{
+				timeout: 100 * time.Millisecond,
+				ChromeRun: func(ctx context.Context, actions ...chromedp.Action) error {
+					return tt.runErr
+				},
+				DocumentReader: func(r io.Reader) (*goquery.Document, error) {
+					if tt.docReaderErr != nil {
+						return nil, tt.docReaderErr
+					}
+					return goquery.NewDocumentFromReader(strings.NewReader("<html><body>Test</body></html>"))
+				},
+			}
+
+			doc, err := dr.RetrieveDocument("https://example.com", nil, "body")
+
+			if tt.expectErr {
+				assert.Error(t, err)
+				assert.Nil(t, doc)
+				if tt.runErr == context.DeadlineExceeded {
+					assert.ErrorIs(t, err, context.DeadlineExceeded)
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, doc)
+			}
+		})
+	}
+}
+
+func TestRetrieveDocument_VerifiesActions(t *testing.T) {
+	url := "https://example.com"
+	headers := network.Headers{"User-Agent": "test-agent"}
+	selector := ".content"
+
+	actionTypes := make(map[string]bool)
+	actionsExecuted := false
+
+	dr := &DocumentRetriever{
+		timeout: 5 * time.Second,
+		ChromeRun: func(ctx context.Context, actions ...chromedp.Action) error {
+			actionsExecuted = true
+			// Since we can't reliably identify the action types,
+			// we'll just count the actions and verify that the expected number are present
+			actionsCount := len(actions)
+
+			// We expect at least 4 actions: network.Enable, SetExtraHTTPHeaders, Navigate, WaitReady, OuterHTML
+			if actionsCount >= 4 {
+				actionTypes["all_actions_present"] = true
+			}
+			return nil
+		},
+		DocumentReader: func(r io.Reader) (*goquery.Document, error) {
+			return goquery.NewDocumentFromReader(strings.NewReader("<html><body>Test</body></html>"))
+		},
+	}
+
+	dr.RetrieveDocument(url, headers, selector)
+	assert.True(t, actionsExecuted, "Actions were not executed")
+	assert.True(t, actionTypes["all_actions_present"], "Not enough actions were executed")
+}
+
+func TestDocumentRetriever_Integration(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	dr := NewDocumentRetriever(10 * time.Second)
+	doc, err := dr.RetrieveDocument("https://example.com", nil, "body")
+	assert.NoError(t, err)
+	assert.NotNil(t, doc)
+
+	html, err := doc.Html()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, html)
 }


### PR DESCRIPTION
## Context
- Refactored `getBasicBoxScoreStats` and `GetMatchups` to use `networkHeaders` and `DocumentRetriever`
- Logging is more concise and better for `getBasicBoxScoreStats`
- Slight refactor of `getBasicBoxScoreStats` to use shared components
- Added `GetAdvBoxScoreStats` to scrape NBA advanced box score stats from basketball-reference.com
- `NBAAdvBoxScoreStats` is the data model for NBA Advanced box score stats from basketball-reference.com
- Created shared.go for shared components for scraping NBA box score data from basketball-reference.com
- Created functions to extract player ID and transform player minutes played
- Added tests for newer functions