### PR TITLE
Better scraper configurations and control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Added
+- Created `RetrieverOption` to make `NewDocumentRetriever` more configurable with default values to keep the function signature consistent long term
+### Changed
+- Updated `NewDocumentRetriever` function signature
 ## [0.1.0-alpha.1] - 2025-03-02
 ### Added
 - Added `GetAdvBoxScoreStats` to scrape NBA advanced box score stats from basketball-reference.com (#5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Created `Runner`, `MatchupRunner`, and `BoxScoreRunner` in base_runner.go as sportreference utils to better configure and facilitate scraping for basketball-reference.com matchups and box scores
 - Created `RetrieverOption` to make `NewDocumentRetriever` more configurable with default values to keep the function signature consistent long term
 ### Changed
 - Updated `NewDocumentRetriever` function signature
+- Refactored each scraping process to inherit from `MatchupRunner` and `BoxScoreRunner`
+- Each box score stats scraper uses `Processor.GetSegmentBoxScoreStats` to orchestrate scraping.
+- All round better configuration
+- Update logging all over to use `log`
+
 ## [0.1.0-alpha.1] - 2025-03-02
 ### Added
 - Added `GetAdvBoxScoreStats` to scrape NBA advanced box score stats from basketball-reference.com (#5)

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ go get github.com/lightning-dabbler/sportscrape
 
 ## Data providers
 
-| Source                           | League | Feed                  | Function
-|----------------------------------|--------|-----------------------|-----------------------|
-| https://basketball-reference.com | NBA    | Matchup               | `GetMatchups(date)`   |
-| https://basketball-reference.com | NBA    | Basic box score stats | `GetBasicBoxScoreStats(concurrency, matchups...)` |
-| https://basketball-reference.com | NBA    | Advanced box score stats | `GetAdvBoxScoreStats(concurrency, matchups...)` |
+| Source                           | League | Feed                  |
+|----------------------------------|--------|-----------------------|
+| https://basketball-reference.com | NBA    | Matchup               |
+| https://basketball-reference.com | NBA    | Basic box score stats |
+| https://basketball-reference.com | NBA    | Advanced box score stats|
 
 ## License
 MIT

--- a/dataprovider/basketballreference/nba/adv_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/adv_box_score_stats.go
@@ -71,7 +71,7 @@ func getAdvBoxScoreStats(nbaMatchup interface{}) []interface{} {
 	start := time.Now().UTC()
 	var advNBABoxScoreStats []interface{}
 	fmt.Println("Scraping Advanced Box Score: " + url)
-	dr := request.NewDocumentRetriever(2 * time.Minute)
+	dr := request.NewDocumentRetriever(request.WithTimeout(2 * time.Minute))
 	doc, err := dr.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
 	if err != nil {
 		log.Fatalln(err)

--- a/dataprovider/basketballreference/nba/adv_box_score_stats_test.go
+++ b/dataprovider/basketballreference/nba/adv_box_score_stats_test.go
@@ -4,6 +4,7 @@ package nba
 
 import (
 	"testing"
+	"time"
 
 	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference/nba/model"
 	"github.com/stretchr/testify/assert"
@@ -14,8 +15,15 @@ func TestGetAdvBoxScoreStats(t *testing.T) {
 		t.Skip("Skipping integration test")
 	}
 	date := "2025-02-19"
-	matchups := GetMatchups(date)
-	advBoxScoreStats := GetAdvBoxScoreStats(1, matchups...)
+	matchupRunner := NewMatchupRunner(
+		WithMatchupTimeout(2 * time.Minute),
+	)
+	matchups := matchupRunner.GetMatchups(date)
+	boxScoreRunner := NewAdvBoxScoreRunner(
+		WithAdvBoxScoreTimeout(4*time.Minute),
+		WithAdvBoxScoreConcurrency(1),
+	)
+	advBoxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
 	numAwayPlayers := 0
 	numHomePlayers := 0
 	numAwayDNP := 0

--- a/dataprovider/basketballreference/nba/basic_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/basic_box_score_stats.go
@@ -82,7 +82,7 @@ func getBasicBoxScoreStats(nbaMatchup interface{}) []interface{} {
 	start := time.Now().UTC()
 	var basicNBABoxScoreStats []interface{}
 	fmt.Println("Scraping Basic Box Score: " + url)
-	dr := request.NewDocumentRetriever(2 * time.Minute)
+	dr := request.NewDocumentRetriever(request.WithTimeout(2 * time.Minute))
 	doc, err := dr.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
 	if err != nil {
 		log.Fatalln(err)

--- a/dataprovider/basketballreference/nba/basic_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/basic_box_score_stats.go
@@ -3,14 +3,13 @@ package nba
 import (
 	"fmt"
 	"log"
-	"sync"
 	"time"
 	"unicode"
 
 	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference"
 	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference/nba/model"
 	"github.com/lightning-dabbler/sportscrape/util"
-	"github.com/lightning-dabbler/sportscrape/util/request"
+	sportsreferenceutil "github.com/lightning-dabbler/sportscrape/util/sportsreference"
 
 	"github.com/PuerkitoBio/goquery"
 )
@@ -72,18 +71,63 @@ var basicBoxScoreReservesHeaderValues headerValues = headerValues{
 	"+/-":      struct{}{},
 }
 
-// getBasicBoxScoreStats accepts an interface that represents model.NBAMatchup
-// It fetches the basic box score stats associated with that matchup
-// Returns an array of model.NBABasicBoxScoreStats in the form of interface{}
-func getBasicBoxScoreStats(nbaMatchup interface{}) []interface{} {
-	matchup := nbaMatchup.(model.NBAMatchup)
-	url := matchup.BoxScoreLink
+// BasicBoxScoreOption defines a configuration option for basic box score runners
+type BasicBoxScoreOption func(*BasicBoxScoreRunner)
+
+// WithBasicBoxScoreTimeout sets the timeout duration for basic box score runner
+func WithBasicBoxScoreTimeout(timeout time.Duration) BasicBoxScoreOption {
+	return func(bsr *BasicBoxScoreRunner) {
+		bsr.Timeout = timeout
+	}
+}
+
+// WithBasicBoxScoreDebug enables or disables debug mode for basic box score runner
+func WithBasicBoxScoreDebug(debug bool) BasicBoxScoreOption {
+	return func(bsr *BasicBoxScoreRunner) {
+		bsr.Debug = debug
+	}
+}
+
+// WithBasicBoxScoreConcurrency sets the number of concurrent workers
+func WithBasicBoxScoreConcurrency(n int) BasicBoxScoreOption {
+	return func(bsr *BasicBoxScoreRunner) {
+		bsr.Concurrency = n
+	}
+}
+
+// NewBasicBoxScoreRunner creates a new BasicBoxScoreRunner with the provided options
+func NewBasicBoxScoreRunner(options ...BasicBoxScoreOption) *BasicBoxScoreRunner {
+	bsr := &BasicBoxScoreRunner{}
+	bsr.Processor = bsr
+
+	// Apply all options
+	for _, option := range options {
+		option(bsr)
+	}
+
+	return bsr
+}
+
+// BasicBoxScoreRunner specialized Runner for retrieving NBA basic box score statistics
+// with support for concurrent processing.
+type BasicBoxScoreRunner struct {
+	sportsreferenceutil.BoxScoreRunner
+}
+
+// GetSegmentBoxScoreStats retrieves NBA basic box score statistics for a single matchup.
+//
+// Parameter:
+//   - matchup: The NBA matchup for which to retrieve basic box score statistics
+//
+// Returns a slice of NBA basic box score statistics as interface{} values
+func (boxScoreRunner *BasicBoxScoreRunner) GetSegmentBoxScoreStats(matchup interface{}) []interface{} {
+	matchupModel := matchup.(model.NBAMatchup)
+	url := matchupModel.BoxScoreLink
 	PullTimestamp := time.Now().UTC()
 	start := time.Now().UTC()
 	var basicNBABoxScoreStats []interface{}
-	fmt.Println("Scraping Basic Box Score: " + url)
-	dr := request.NewDocumentRetriever(request.WithTimeout(2 * time.Minute))
-	doc, err := dr.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
+	log.Println("Scraping Basic Box Score: " + url)
+	doc, err := boxScoreRunner.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -102,15 +146,15 @@ func getBasicBoxScoreStats(nbaMatchup interface{}) []interface{} {
 			var boxScoreStats model.NBABasicBoxScoreStats
 			if j < 5 || j > 5 {
 				boxScoreStats.PullTimestamp = PullTimestamp
-				boxScoreStats.EventID = matchup.EventID
+				boxScoreStats.EventID = matchupModel.EventID
 				if i == 0 {
-					boxScoreStats.Team = matchup.AwayTeam
-					boxScoreStats.Opponent = matchup.HomeTeam
+					boxScoreStats.Team = matchupModel.AwayTeam
+					boxScoreStats.Opponent = matchupModel.HomeTeam
 				} else {
-					boxScoreStats.Team = matchup.HomeTeam
-					boxScoreStats.Opponent = matchup.AwayTeam
+					boxScoreStats.Team = matchupModel.HomeTeam
+					boxScoreStats.Opponent = matchupModel.AwayTeam
 				}
-				boxScoreStats.EventDate = matchup.EventDate
+				boxScoreStats.EventDate = matchupModel.EventDate
 				if j < 5 {
 					boxScoreStats.Starter = true
 				} else {
@@ -307,45 +351,11 @@ func getBasicBoxScoreStats(nbaMatchup interface{}) []interface{} {
 		})
 	})
 	if len(basicNBABoxScoreStats) == 0 {
-		fmt.Printf("No Data Scraped @ %s\n", url)
+		log.Printf("No Data Scraped @ %s\n", url)
 	} else {
 		diff := time.Now().UTC().Sub(start)
-		fmt.Printf("Scraping of %s Completed in %s\n", url, diff)
+		log.Printf("Scraping of %s Completed in %s\n", url, diff)
 	}
 
 	return basicNBABoxScoreStats
-}
-
-// basicBoxScoreStatsWorker acts a worker for retrieving and constructing basic box score stats
-func basicBoxScoreStatsWorker(wg *sync.WaitGroup, workerNBAMatchups <-chan interface{}, boxScoreStats chan<- []interface{}) {
-	for matchup := range workerNBAMatchups {
-		boxScoreStats <- getBasicBoxScoreStats(matchup)
-		wg.Done()
-	}
-}
-
-// GetBasicBoxScoreStats retrieves all basic box score stats for all matchups
-// It accepts a concurrency integer to parallelize the requests
-// Returns an array of model.NBABasicBoxScoreStats in the form of interface{}
-func GetBasicBoxScoreStats(concurrency int, matchups ...interface{}) []interface{} {
-	var wg sync.WaitGroup
-	workerNBAMatchups := make(chan interface{}, concurrency)
-	BoxScoreStats := make(chan []interface{}, len(matchups))
-	for i := 0; i < cap(workerNBAMatchups); i++ {
-		go basicBoxScoreStatsWorker(&wg, workerNBAMatchups, BoxScoreStats)
-	}
-	for _, matchup := range matchups {
-		wg.Add(1)
-		workerNBAMatchups <- matchup
-	}
-	wg.Wait()
-	close(workerNBAMatchups)
-	close(BoxScoreStats)
-
-	var allBoxScoreStats []interface{}
-	for boxScoreStats := range BoxScoreStats {
-		allBoxScoreStats = append(allBoxScoreStats, boxScoreStats...)
-
-	}
-	return allBoxScoreStats
 }

--- a/dataprovider/basketballreference/nba/basic_box_score_stats_test.go
+++ b/dataprovider/basketballreference/nba/basic_box_score_stats_test.go
@@ -4,6 +4,7 @@ package nba
 
 import (
 	"testing"
+	"time"
 
 	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference/nba/model"
 	"github.com/stretchr/testify/assert"
@@ -14,8 +15,15 @@ func TestGetBasicBoxScoreStats(t *testing.T) {
 		t.Skip("Skipping integration test")
 	}
 	date := "2025-02-19"
-	matchups := GetMatchups(date)
-	basicBoxScoreStats := GetBasicBoxScoreStats(1, matchups...)
+	matchupRunner := NewMatchupRunner(
+		WithMatchupTimeout(2 * time.Minute),
+	)
+	matchups := matchupRunner.GetMatchups(date)
+	boxScoreRunner := NewBasicBoxScoreRunner(
+		WithBasicBoxScoreTimeout(4*time.Minute),
+		WithBasicBoxScoreConcurrency(1),
+	)
+	basicBoxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
 	numAwayPlayers := 0
 	numHomePlayers := 0
 	numAwayDNP := 0

--- a/dataprovider/basketballreference/nba/example_test.go
+++ b/dataprovider/basketballreference/nba/example_test.go
@@ -2,36 +2,64 @@ package nba_test
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference/nba"
 	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference/nba/model"
 )
 
-// Example for nba.GetMatchups
-func ExampleGetMatchups() {
+// Example for nba.MatchupRunner
+func ExampleMatchupRunner() {
 	date := "2025-02-20"
-	matchups := nba.GetMatchups(date)
+	// Instantiate MatchupRunner
+	runner := nba.NewMatchupRunner(
+		nba.WithMatchupTimeout(2 * time.Minute),
+	)
+	// Retrieve NBA matchups associated with date
+	matchups := runner.GetMatchups(date)
 	for _, matchup := range matchups {
 		fmt.Printf("%#v\n", matchup.(model.NBAMatchup))
 	}
 }
 
-// Example for nba.GetBasicBoxScoreStats
-func ExampleGetBasicBoxScoreStats() {
+// Example for nba.BasicBoxScoreRunner
+func ExampleBasicBoxScoreRunner() {
 	date := "2025-02-19"
-	matchups := nba.GetMatchups(date)
-	basicBoxScoreStats := nba.GetBasicBoxScoreStats(1, matchups...)
+	// Instantiate MatchupRunner
+	matchupRunner := nba.NewMatchupRunner(
+		nba.WithMatchupTimeout(2 * time.Minute),
+	)
+	// Retrieve NBA matchups associated with date
+	matchups := matchupRunner.GetMatchups(date)
+	// Instantiate BasicBoxScoreRunner
+	boxScoreRunner := nba.NewBasicBoxScoreRunner(
+		nba.WithBasicBoxScoreTimeout(4*time.Minute),
+		nba.WithBasicBoxScoreConcurrency(1),
+	)
+	// Retrieve NBA basic box score stats associated with matchups
+	basicBoxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
 
 	for _, stats := range basicBoxScoreStats {
 		fmt.Printf("%#v\n", stats.(model.NBABasicBoxScoreStats))
 	}
 }
 
-// Example for nba.GetAdvBoxScoreStats
-func ExampleGetAdvBoxScoreStats() {
+// Example for nba.AdvBoxScoreRunner
+func ExampleAdvBoxScoreRunner() {
 	date := "2025-02-19"
-	matchups := nba.GetMatchups(date)
-	advBoxScoreStats := nba.GetAdvBoxScoreStats(1, matchups...)
+	// Instantiate MatchupRunner
+	matchupRunner := nba.NewMatchupRunner(
+		nba.WithMatchupTimeout(2 * time.Minute),
+	)
+	// Retrieve NBA matchups associated with date
+	matchups := matchupRunner.GetMatchups(date)
+	// Instantiate AdvBoxScoreRunner
+	boxScoreRunner := nba.NewAdvBoxScoreRunner(
+		nba.WithAdvBoxScoreTimeout(4*time.Minute),
+		nba.WithAdvBoxScoreConcurrency(1),
+	)
+	// Retrieve NBA advanced box score stats associated with matchups
+	advBoxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
 
 	for _, stats := range advBoxScoreStats {
 		fmt.Printf("%#v\n", stats.(model.NBAAdvBoxScoreStats))

--- a/dataprovider/basketballreference/nba/matchups.go
+++ b/dataprovider/basketballreference/nba/matchups.go
@@ -63,7 +63,7 @@ func GetMatchups(date string) []interface{} {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	dr := request.NewDocumentRetriever(60 * time.Second)
+	dr := request.NewDocumentRetriever(request.WithTimeout(60 * time.Second))
 
 	doc, err := dr.RetrieveDocument(url, networkHeaders, matchupsGameSummariesSelector)
 	if err != nil {

--- a/dataprovider/basketballreference/nba/matchups_test.go
+++ b/dataprovider/basketballreference/nba/matchups_test.go
@@ -4,6 +4,7 @@ package nba
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -31,7 +32,10 @@ func TestGetMatchups(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			matchups := GetMatchups(tt.date)
+			runner := NewMatchupRunner(
+				WithMatchupTimeout(2 * time.Minute),
+			)
+			matchups := runner.GetMatchups(tt.date)
 			assert.Equal(t, tt.expectedNumMatches, len(matchups))
 		})
 	}

--- a/util/request/request.go
+++ b/util/request/request.go
@@ -68,7 +68,7 @@ func WithDebug(debug bool) RetrieverOption {
 // which can be overridden by the provided options.
 //
 // By default, the retriever uses:
-//   - 30 second timeout
+//   - 1 minute timeout
 //   - Debug logging disabled
 //   - Standard chromedp.Run for Chrome operations
 //   - Standard goquery document parser
@@ -80,7 +80,7 @@ func WithDebug(debug bool) RetrieverOption {
 func NewDocumentRetriever(options ...RetrieverOption) *DocumentRetriever {
 	// Set defaults
 	dr := &DocumentRetriever{
-		Timeout:        30 * time.Second,
+		Timeout:        1 * time.Minute,
 		Debug:          false,
 		ChromeRun:      chromedp.Run,
 		DocumentReader: goquery.NewDocumentFromReader,

--- a/util/request/request_test.go
+++ b/util/request/request_test.go
@@ -356,37 +356,3 @@ func TestRetrieveDocument_VerifiesActions(t *testing.T) {
 	assert.True(t, actionsExecuted, "Actions were not executed")
 	assert.True(t, actionTypes["all_actions_present"], "Not enough actions were executed")
 }
-
-func TestDocumentRetriever_Integration(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	dr := NewDocumentRetriever(WithTimeout(10 * time.Second))
-	doc, err := dr.RetrieveDocument("https://example.com", nil, "body")
-	assert.NoError(t, err)
-	assert.NotNil(t, doc)
-
-	html, err := doc.Html()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, html)
-}
-
-// TestDocumentRetriever_IntegrationWithDebug tests integration with debug mode on
-func TestDocumentRetriever_IntegrationWithDebug(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping integration test")
-	}
-
-	dr := NewDocumentRetriever(
-		WithTimeout(10*time.Second),
-		WithDebug(true),
-	)
-	doc, err := dr.RetrieveDocument("https://example.com", nil, "body")
-	assert.NoError(t, err)
-	assert.NotNil(t, doc)
-
-	html, err := doc.Html()
-	assert.NoError(t, err)
-	assert.NotEmpty(t, html)
-}

--- a/util/request/request_test.go
+++ b/util/request/request_test.go
@@ -107,9 +107,10 @@ func TestGetIntegrationTests(t *testing.T) {
 
 func TestNewDocumentRetriever(t *testing.T) {
 	timeout := 30 * time.Second
-	dr := NewDocumentRetriever(timeout)
+	dr := NewDocumentRetriever()
 
-	assert.Equal(t, timeout, dr.timeout)
+	assert.Equal(t, timeout, dr.Timeout)
+	assert.Equal(t, false, dr.Debug)
 	assert.NotNil(t, dr.ChromeRun)
 	assert.NotNil(t, dr.DocumentReader)
 }
@@ -150,7 +151,7 @@ func TestRetrieveDocument(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			dr := &DocumentRetriever{
-				timeout: 100 * time.Millisecond,
+				Timeout: 100 * time.Millisecond,
 				ChromeRun: func(ctx context.Context, actions ...chromedp.Action) error {
 					return tt.runErr
 				},
@@ -215,7 +216,7 @@ func TestDocumentRetriever_Integration(t *testing.T) {
 		t.Skip("Skipping integration test")
 	}
 
-	dr := NewDocumentRetriever(10 * time.Second)
+	dr := NewDocumentRetriever(WithTimeout(10 * time.Second))
 	doc, err := dr.RetrieveDocument("https://example.com", nil, "body")
 	assert.NoError(t, err)
 	assert.NotNil(t, doc)

--- a/util/sportsreference/base_runner.go
+++ b/util/sportsreference/base_runner.go
@@ -1,0 +1,134 @@
+package sportsreferenceutil
+
+import (
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/chromedp/cdproto/network"
+	"github.com/lightning-dabbler/sportscrape/util/request"
+)
+
+// Runner provides base functionality for retrieving documents from web pages.
+// It encapsulates configuration for document retrieval operations.
+type Runner struct {
+	// Timeout is the context timeout for Chrome operations
+	Timeout time.Duration
+	// Debug enables verbose logging of Chrome operations when true
+	Debug bool
+}
+
+// RetrieveDocument fetches and parses a web document from the specified URL.
+// It uses a DocumentRetriever to load the page and parse it into a goquery Document.
+//
+// Parameters:
+//   - url: The web page URL to retrieve
+//   - networkHeaders: HTTP headers to include with the request
+//   - waitReadySelector: CSS selector of element that indicates page is fully loaded
+//
+// Returns:
+//   - *goquery.Document: The parsed document
+//   - error: Any error encountered during fetching or parsing
+func (runner *Runner) RetrieveDocument(url string, networkHeaders network.Headers, waitReadySelector string) (*goquery.Document, error) {
+	var retrieveOptions []request.RetrieverOption
+	// Only add the timeout option if it's non-zero
+	if runner.Timeout != 0 {
+		retrieveOptions = append(retrieveOptions, request.WithTimeout(runner.Timeout))
+	}
+
+	// Add debug option
+	if runner.Debug {
+		retrieveOptions = append(retrieveOptions, request.WithDebug(runner.Debug))
+	}
+
+	// Create the document retriever with the collected options
+	dr := request.NewDocumentRetriever(retrieveOptions...)
+	return dr.RetrieveDocument(url, networkHeaders, waitReadySelector)
+}
+
+// MatchupRunner specialized Runner for retrieving matchup information.
+type MatchupRunner struct {
+	Runner
+}
+
+// GetMatchups retrieves matchups for the specified date.
+//
+// Parameter:
+//   - date: The date for which to retrieve matchups
+//
+// Returns a slice of matchup data as interface{} values
+func (matchupRunner *MatchupRunner) GetMatchups(date string) []interface{} {
+	return []interface{}{}
+}
+
+// BoxScoreProcessor defines the interface for processing box scores
+type BoxScoreProcessor interface {
+	GetSegmentBoxScoreStats(matchup interface{}) []interface{}
+}
+
+// BoxScoreRunner specialized Runner for retrieving box score statistics
+// with support for concurrent processing.
+type BoxScoreRunner struct {
+	Runner
+	// Concurrency sets the maximum number of concurrent workers to request documents
+	Concurrency int
+	// Processor defines the interface for processing box scores
+	Processor BoxScoreProcessor
+}
+
+// GetBoxScoresStats retrieves box score statistics for the provided matchups
+// using concurrent workers for improved performance.
+//
+// Parameter:
+//   - matchups: A variadic list of matchups to process
+//
+// Returns a slice containing all box score statistics as interface{} values
+func (boxScoreRunner *BoxScoreRunner) GetBoxScoresStats(matchups ...interface{}) []interface{} {
+	// Set default concurrency if not specified
+	concurrency := boxScoreRunner.Concurrency
+	if concurrency <= 0 {
+		concurrency = runtime.NumCPU()
+	}
+
+	var wg sync.WaitGroup
+	workerMatchups := make(chan interface{}, concurrency)
+	BoxScoreStats := make(chan []interface{}, len(matchups))
+
+	// Start worker goroutines
+	for i := 0; i < cap(workerMatchups); i++ {
+		go boxScoreRunner.Worker(&wg, workerMatchups, BoxScoreStats)
+	}
+
+	// Send matchups to workers
+	for _, matchup := range matchups {
+		wg.Add(1)
+		workerMatchups <- matchup
+	}
+
+	wg.Wait()
+	close(workerMatchups)
+	close(BoxScoreStats)
+
+	// Collect results
+	var allBoxScoreStats []interface{}
+	for boxScoreStats := range BoxScoreStats {
+		allBoxScoreStats = append(allBoxScoreStats, boxScoreStats...)
+	}
+
+	return allBoxScoreStats
+}
+
+// Worker processes matchups from the input channel and sends resulting box score
+// statistics to the output channel. Designed to be run as a goroutine.
+//
+// Parameters:
+//   - wg: WaitGroup for synchronizing worker completion
+//   - workerMatchups: Channel providing matchups to process
+//   - boxScoreStats: Channel for sending processed box score statistics
+func (boxScoreRunner *BoxScoreRunner) Worker(wg *sync.WaitGroup, workerMatchups <-chan interface{}, boxScoreStats chan<- []interface{}) {
+	for matchup := range workerMatchups {
+		boxScoreStats <- boxScoreRunner.Processor.GetSegmentBoxScoreStats(matchup)
+		wg.Done()
+	}
+}

--- a/util/sportsreference/base_runner_test.go
+++ b/util/sportsreference/base_runner_test.go
@@ -1,0 +1,186 @@
+//go:build unit
+
+package sportsreferenceutil
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Simple implementation of BoxScoreProcessor for testing
+type TestBoxScoreProcessor struct{}
+
+func (p *TestBoxScoreProcessor) GetSegmentBoxScoreStats(matchup interface{}) []interface{} {
+	// Simple implementation that returns the matchup in a slice
+	return []interface{}{matchup}
+}
+
+// TestMatchupRunnerStructure verifies MatchupRunner embeds Runner properly
+func TestMatchupRunnerStructure(t *testing.T) {
+	// Verify MatchupRunner embeds Runner
+	runner := MatchupRunner{
+		Runner: Runner{
+			Timeout: 5 * time.Second,
+			Debug:   true,
+		},
+	}
+
+	// Check that Runner fields are accessible
+	if runner.Timeout != 5*time.Second {
+		t.Errorf("Expected Timeout to be 5s, got %v", runner.Timeout)
+	}
+
+	if !runner.Debug {
+		t.Errorf("Expected Debug to be true, got false")
+	}
+
+	// Since GetMatchups is likely a placeholder meant to be overridden,
+	// we'll just verify it exists and returns a non-nil value
+	result := runner.GetMatchups("2023-01-01")
+	if result == nil {
+		t.Errorf("GetMatchups should return non-nil, even if empty")
+	}
+}
+
+// TestBoxScoreRunnerGetBoxScoresStats tests the BoxScoreRunner.GetBoxScoresStats method
+func TestBoxScoreRunnerGetBoxScoresStats(t *testing.T) {
+	processor := &TestBoxScoreProcessor{}
+
+	testCases := []struct {
+		name        string
+		concurrency int
+		matchups    []interface{}
+		expected    int
+	}{
+		{
+			name:        "No matchups",
+			concurrency: 2,
+			matchups:    []interface{}{},
+			expected:    0,
+		},
+		{
+			name:        "Single matchup",
+			concurrency: 2,
+			matchups:    []interface{}{1},
+			expected:    1,
+		},
+		{
+			name:        "Multiple matchups",
+			concurrency: 2,
+			matchups:    []interface{}{1, 2, 3},
+			expected:    3,
+		},
+		{
+			name:        "Default concurrency",
+			concurrency: 0, // Should use runtime.NumCPU()
+			matchups:    []interface{}{1, 2, 3, 4},
+			expected:    4,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := &BoxScoreRunner{
+				Runner: Runner{
+					Timeout: 1 * time.Second,
+				},
+				Concurrency: tc.concurrency,
+				Processor:   processor,
+			}
+
+			results := runner.GetBoxScoresStats(tc.matchups...)
+
+			if len(results) != tc.expected {
+				t.Errorf("Expected %d results, got %d", tc.expected, len(results))
+			}
+
+			// Verify each matchup was processed correctly
+			for i, matchup := range tc.matchups {
+				if i < len(results) && !reflect.DeepEqual(results[i], matchup) {
+					t.Errorf("Result %d doesn't match input: expected %v, got %v", i, matchup, results[i])
+				}
+			}
+		})
+	}
+}
+
+// TestBoxScoreRunnerWorker tests the BoxScoreRunner.Worker method directly
+func TestBoxScoreRunnerWorker(t *testing.T) {
+	processor := &TestBoxScoreProcessor{}
+	runner := &BoxScoreRunner{
+		Processor: processor,
+	}
+
+	// Test data
+	matchups := []interface{}{1, "test", map[string]string{"key": "value"}}
+
+	// Setup channels and wait group
+	var wg sync.WaitGroup
+	workerMatchups := make(chan interface{}, len(matchups))
+	boxScoreStats := make(chan []interface{}, len(matchups))
+
+	// Start worker
+	go runner.Worker(&wg, workerMatchups, boxScoreStats)
+
+	// Send matchups to worker
+	for _, m := range matchups {
+		wg.Add(1)
+		workerMatchups <- m
+	}
+
+	// Wait for processing to complete
+	wg.Wait()
+	close(workerMatchups)
+	close(boxScoreStats)
+
+	// Collect results
+	var results []interface{}
+	for stats := range boxScoreStats {
+		results = append(results, stats...)
+	}
+
+	// Verify results
+	if len(results) != len(matchups) {
+		t.Errorf("Expected %d results, got %d", len(matchups), len(results))
+	}
+
+	// Verify each result matches its input
+	for i, m := range matchups {
+		if i < len(results) && !reflect.DeepEqual(results[i], m) {
+			t.Errorf("Result %d doesn't match input: expected %v, got %v", i, m, results[i])
+		}
+	}
+}
+
+// TestRunnerStructureAndOptions verifies the Runner structure and its configuration options
+func TestRunnerStructureAndOptions(t *testing.T) {
+	testCases := []struct {
+		name    string
+		timeout time.Duration
+		debug   bool
+	}{
+		{"Default", 0, false},
+		{"WithTimeout", 5 * time.Second, false},
+		{"WithDebug", 0, true},
+		{"WithTimeoutAndDebug", 5 * time.Second, true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			runner := Runner{
+				Timeout: tc.timeout,
+				Debug:   tc.debug,
+			}
+
+			if runner.Timeout != tc.timeout {
+				t.Errorf("Expected Timeout to be %v, got %v", tc.timeout, runner.Timeout)
+			}
+
+			if runner.Debug != tc.debug {
+				t.Errorf("Expected Debug to be %v, got %v", tc.debug, runner.Debug)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context
### Added
- Created `Runner`, `MatchupRunner`, and `BoxScoreRunner` in base_runner.go as sportreference utils to better configure and facilitate scraping for basketball-reference.com matchups and box scores
- Created `RetrieverOption` to make `NewDocumentRetriever` more configurable with default values to keep the function signature consistent long term
### Changed
- Updated `NewDocumentRetriever` function signature
- Refactored each scraping process to inherit from `MatchupRunner` and `BoxScoreRunner`
- Each box score stats scraper uses `Processor.GetSegmentBoxScoreStats` to orchestrate scraping.
- All round better configuration
- Update logging all over to use `log`

Fixes #8 