### PR TITLE
Baseball-reference MLB data

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -4,9 +4,19 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - 'util/**'
+      - 'dataprovider/**'
   push:
     branches:
       - main
+    paths:
+      - 'go.mod'
+      - 'go.sum'
+      - 'util/**'
+      - 'dataprovider/**'
 
 jobs:
   all-tests:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,6 +3,11 @@ name: Unit tests
 on:
   push:
     branches-ignore: [main]
+  paths:
+    - 'go.mod'
+    - 'go.sum'
+    - 'util/**'
+    - 'dataprovider/**'
 
 jobs:
   unit-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Added `MLBMatchup` model and `MatchupRunner` to scrape MLB matchups from https://baseball-reference.com
 - Added EventID to sportsreference util and updated `MatchupRunner.GetMatchups(...)` to use it.
 ### Changed
 - Moved local extractPlayerID to sportsreference util and renamed it PlayerID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added EventID to sportsreference util and updated `MatchupRunner.GetMatchups(...)` to use it.
+### Changed
+- Moved local extractPlayerID to sportsreference util and renamed it PlayerID
 
 ## [0.1.0-beta] - 2025-03-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added EventID to sportsreference util and updated `MatchupRunner.GetMatchups(...)` to use it.
 ### Changed
 - Moved local extractPlayerID to sportsreference util and renamed it PlayerID
+- Changed `headerValues` type from map to slice of string
 
 ## [0.1.0-beta] - 2025-03-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Moved local extractPlayerID to sportsreference util and renamed it PlayerID
 - Changed `headerValues` type from map to slice of string
+- renamed `headerValues` to `Headers`
+- Moved `Headers` to sportsreferenceutil package
 
 ## [0.1.0-beta] - 2025-03-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Created `MLBPitchingBoxScoreStats` model
-- Added `MLBMatchup` model and `MatchupRunner` to scrape MLB matchups from https://baseball-reference.com
-- Added `MLBBattingBoxScoreStats` and `BattingBoxScoreRunner` to scrape MLB batting box score data from https://baseball-reference.com
 - Added EventID to sportsreference util and updated `MatchupRunner.GetMatchups(...)` to use it.
+- Created `MLBMatchup` model and `MatchupRunner` to scrape MLB matchups from https://baseball-reference.com
+- Created `MLBBattingBoxScoreStats` and `BattingBoxScoreRunner` to scrape MLB batting box score data from https://baseball-reference.com
+- Created `MLBPitchingBoxScoreStats` model and `PitchingBoxScoreRunner` to scrape MLB pitching box score data from https://baseball-reference.com
 ### Changed
 - Moved local extractPlayerID to sportsreference util and renamed it PlayerID
 - Changed `headerValues` type from map to slice of string

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added `MLBMatchup` model and `MatchupRunner` to scrape MLB matchups from https://baseball-reference.com
+- Added `MLBBattingBoxScoreStats` and `BattingBoxScoreRunner` to scrape MLB batting box score data from https://baseball-reference.com
 - Added EventID to sportsreference util and updated `MatchupRunner.GetMatchups(...)` to use it.
 ### Changed
 - Moved local extractPlayerID to sportsreference util and renamed it PlayerID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Created `MLBPitchingBoxScoreStats` model
 - Added `MLBMatchup` model and `MatchupRunner` to scrape MLB matchups from https://baseball-reference.com
 - Added `MLBBattingBoxScoreStats` and `BattingBoxScoreRunner` to scrape MLB batting box score data from https://baseball-reference.com
 - Added EventID to sportsreference util and updated `MatchupRunner.GetMatchups(...)` to use it.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ go get github.com/lightning-dabbler/sportscrape
 
 ## Usage
 - [basketball-reference.com NBA scrape examples](dataprovider/basketballreference/nba/example_test.go)
+- [baseball-reference.com NBA scrape examples](dataprovider/baseballreference/mlb/example_test.go)
 
 ## Data providers
 
@@ -16,6 +17,9 @@ go get github.com/lightning-dabbler/sportscrape
 | https://basketball-reference.com | NBA    | Matchup               |
 | https://basketball-reference.com | NBA    | Basic box score stats |
 | https://basketball-reference.com | NBA    | Advanced box score stats|
+| https://baseball-reference.com   | MLB    | Matchup                |
+| https://baseball-reference.com   | MLB    | Batting box score stats|
+| https://baseball-reference.com   | MLB    | Pitching box score stats|
 
 ## License
 MIT

--- a/dataprovider/baseballreference/global.go
+++ b/dataprovider/baseballreference/global.go
@@ -1,0 +1,8 @@
+package baseballreference
+
+const (
+	URI         string = "https://www.baseball-reference.com"
+	MatchupURL  string = URI + "/boxes?month={month}&day={day}&year={year}"
+	BoxScoreURL string = URI + "{route}"
+	Domain      string = "www.baseball-reference.com"
+)

--- a/dataprovider/baseballreference/global.go
+++ b/dataprovider/baseballreference/global.go
@@ -1,8 +1,8 @@
 package baseballreference
 
 const (
-	URI         string = "https://www.baseball-reference.com"
-	MatchupURL  string = URI + "/boxes?month={month}&day={day}&year={year}"
-	BoxScoreURL string = URI + "{route}"
+	URL         string = "https://www.baseball-reference.com"
+	MatchupURL  string = URL + "/boxes?month={month}&day={day}&year={year}"
+	BoxScoreURL string = URL + "{route}"
 	Domain      string = "www.baseball-reference.com"
 )

--- a/dataprovider/baseballreference/mlb/batting_box_score_stats.go
+++ b/dataprovider/baseballreference/mlb/batting_box_score_stats.go
@@ -173,10 +173,11 @@ func parseBattingBoxScore(s *goquery.Selection) *model.MLBBattingBoxScoreStats {
 		return nil
 	}
 	var statline model.MLBBattingBoxScoreStats
+	// Position
 	position := util.CleanTextDatum(s.Find(positionSelector).Text())
 	positionSplit := strings.Split(position, " ")
-
 	statline.Position = positionSplit[len(positionSplit)-1]
+	// Player, PlayerLink, & PlayerID
 	player := s.Find(playerSelector)
 	statline.PlayerLink = baseballreference.URL + util.CleanTextDatum(player.AttrOr("href", ""))
 	statline.Player = util.CleanTextDatum(player.Text())
@@ -189,56 +190,49 @@ func parseBattingBoxScore(s *goquery.Selection) *model.MLBBattingBoxScoreStats {
 	atBatText := util.CleanTextDatum(s.Find("td:nth-child(2)").Text())
 	atBat, err := util.TextToInt(atBatText)
 	if err != nil {
-		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for atBatText to int - %w; defaulting to 0.", atBatText, err))
-		atBat = 0
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for atBatText to int - %w", atBatText, err))
 	}
 	statline.AtBat = atBat
 	// Runs
 	runsText := util.CleanTextDatum(s.Find("td:nth-child(3)").Text())
 	runs, err := util.TextToInt(runsText)
 	if err != nil {
-		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for runsText to int - %w; defaulting to 0.", runsText, err))
-		runs = 0
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for runsText to int - %w", runsText, err))
 	}
 	statline.Runs = runs
 	// Hits
 	hitsText := util.CleanTextDatum(s.Find("td:nth-child(4)").Text())
 	hits, err := util.TextToInt(hitsText)
 	if err != nil {
-		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for hitsText to int - %w; defaulting to 0.", hitsText, err))
-		hits = 0
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for hitsText to int - %w", hitsText, err))
 	}
 	statline.Hits = hits
 	// RunsBattedIn
 	runsBattedInText := util.CleanTextDatum(s.Find("td:nth-child(5)").Text())
 	runsBattedIn, err := util.TextToInt(runsBattedInText)
 	if err != nil {
-		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for runsBattedInText to int - %w; defaulting to 0.", runsBattedInText, err))
-		runsBattedIn = 0
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for runsBattedInText to int - %w", runsBattedInText, err))
 	}
 	statline.RunsBattedIn = runsBattedIn
 	// Walks
 	walksText := util.CleanTextDatum(s.Find("td:nth-child(6)").Text())
 	walks, err := util.TextToInt(walksText)
 	if err != nil {
-		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for walksText to int - %w; defaulting to 0.", walksText, err))
-		walks = 0
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for walksText to int - %w", walksText, err))
 	}
 	statline.Walks = walks
 	// Strikeouts
 	strikeoutsText := util.CleanTextDatum(s.Find("td:nth-child(7)").Text())
 	strikeouts, err := util.TextToInt(strikeoutsText)
 	if err != nil {
-		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for strikeoutsText to int - %w; defaulting to 0.", strikeoutsText, err))
-		strikeouts = 0
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for strikeoutsText to int - %w", strikeoutsText, err))
 	}
 	statline.Strikeouts = strikeouts
 	// PlateAppearances
 	plateAppearancesText := util.CleanTextDatum(s.Find("td:nth-child(8)").Text())
 	plateAppearances, err := util.TextToInt(plateAppearancesText)
 	if err != nil {
-		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for plateAppearancesText to int - %w; defaulting to 0.", plateAppearancesText, err))
-		plateAppearances = 0
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for plateAppearancesText to int - %w", plateAppearancesText, err))
 	}
 	statline.PlateAppearances = plateAppearances
 	// BattingAverage
@@ -362,16 +356,14 @@ func parseBattingBoxScore(s *goquery.Selection) *model.MLBBattingBoxScoreStats {
 	putoutText := util.CleanTextDatum(s.Find("td:nth-child(22)").Text())
 	putout, err := util.TextToInt(putoutText)
 	if err != nil {
-		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for putoutText to int - %w; defaulting to 0.", putoutText, err))
-		putout = 0
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for putoutText to int - %w", putoutText, err))
 	}
 	statline.Putout = putout
 	// Assist
 	assistText := util.CleanTextDatum(s.Find("td:nth-child(23)").Text())
 	assist, err := util.TextToInt(assistText)
 	if err != nil {
-		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for assistText to int - %w; defaulting to 0.", assistText, err))
-		assist = 0
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for assistText to int - %w", assistText, err))
 	}
 	statline.Assist = assist
 	return &statline

--- a/dataprovider/baseballreference/mlb/batting_box_score_stats.go
+++ b/dataprovider/baseballreference/mlb/batting_box_score_stats.go
@@ -1,0 +1,378 @@
+package mlb
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	sportsreferenceutil "github.com/lightning-dabbler/sportscrape/util/sportsreference"
+)
+
+var battingBoxScoreHeaders sportsreferenceutil.Headers = sportsreferenceutil.Headers{
+	"Batting",
+	"AB",
+	"R",
+	"H",
+	"RBI",
+	"BB",
+	"SO",
+	"PA",
+	"BA",
+	"OBP",
+	"SLG",
+	"OPS",
+	"Pit",
+	"Str",
+	"WPA",
+	"aLI",
+	"WPA+",
+	"WPA-",
+	"cWPA",
+	"acLI",
+	"RE24",
+	"PO",
+	"A",
+	"Details",
+}
+
+// BattingBoxScoreOption defines a configuration option for batting box score runners
+type BattingBoxScoreOption func(*BattingBoxScoreRunner)
+
+// WithBattingBoxScoreTimeout sets the timeout duration for batting box score runner
+func WithBattingBoxScoreTimeout(timeout time.Duration) BattingBoxScoreOption {
+	return func(absr *BattingBoxScoreRunner) {
+		absr.Timeout = timeout
+	}
+}
+
+// WithBattingBoxScoreDebug enables or disables debug mode for batting box score runner
+func WithBattingBoxScoreDebug(debug bool) BattingBoxScoreOption {
+	return func(absr *BattingBoxScoreRunner) {
+		absr.Debug = debug
+	}
+}
+
+// WithBattingBoxScoreConcurrency sets the number of concurrent workers
+func WithBattingBoxScoreConcurrency(n int) BattingBoxScoreOption {
+	return func(absr *BattingBoxScoreRunner) {
+		absr.Concurrency = n
+	}
+}
+
+// NewBattingBoxScoreRunner creates a new BattingBoxScoreRunner with the provided options
+func NewBattingBoxScoreRunner(options ...BattingBoxScoreOption) *BattingBoxScoreRunner {
+	absr := &BattingBoxScoreRunner{}
+	absr.Processor = absr
+	//
+
+	// Apply all options
+	for _, option := range options {
+		option(absr)
+	}
+
+	return absr
+}
+
+// BattingBoxScoreRunner specialized Runner for retrieving MLB batting box score statistics
+// with support for concurrent processing.
+type BattingBoxScoreRunner struct {
+	sportsreferenceutil.BoxScoreRunner
+}
+
+// GetSegmentBoxScoreStats retrieves MLB batting box score statistics for a single matchup.
+//
+// Parameter:
+//   - matchup: The MLB matchup for which to retrieve batting box score statistics
+//
+// Returns a slice of MLB batting box score statistics as interface{} values
+func (boxScoreRunner *BattingBoxScoreRunner) GetSegmentBoxScoreStats(matchup interface{}) []interface{} {
+	matchupModel := matchup.(model.MLBMatchup)
+	url := matchupModel.BoxScoreLink
+	PullTimestamp := time.Now().UTC()
+	start := time.Now().UTC()
+	var boxScoreStats []interface{}
+	log.Println("Scraping batting Box Score: " + url)
+	doc, err := boxScoreRunner.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	homeTeamSelector := generateStatTableSelector(matchupModel.HomeTeam, Batting)
+	awayTeamSelector := generateStatTableSelector(matchupModel.AwayTeam, Batting)
+	// Home team batting stat box
+	homeStatBox := doc.Find(homeTeamSelector)
+	// Away team batting stat box
+	awayStatBox := doc.Find(awayTeamSelector)
+	// Validate headers and their positions for each team's stat box
+	homeStatBox.Find(headersSelector).Each(func(idx int, s *goquery.Selection) {
+		header := util.CleanTextDatum(s.Text())
+		expectedHeader := battingBoxScoreHeaders[idx]
+		if header != expectedHeader {
+			log.Fatalf("Home team header '%s' at position %d does not equal expected header '%s' @ %s\n", header, idx, expectedHeader, url)
+		}
+	})
+
+	awayStatBox.Find(headersSelector).Each(func(idx int, s *goquery.Selection) {
+		header := util.CleanTextDatum(s.Text())
+		expectedHeader := battingBoxScoreHeaders[idx]
+		if header != expectedHeader {
+			log.Fatalf("Away team header '%s' at position %d does not equal expected header '%s' @ %s\n", header, idx, expectedHeader, url)
+		}
+	})
+
+	// Parse records - home team
+	homeStatBox.Find(recordSelector).EachWithBreak(func(_ int, s *goquery.Selection) bool {
+		statline := parseBattingBoxScore(s)
+		if statline == nil {
+			return false
+		}
+		statline.PullTimestamp = PullTimestamp
+		statline.EventID = matchupModel.EventID
+		statline.Team = matchupModel.HomeTeam
+		statline.Opponent = matchupModel.AwayTeam
+		statline.EventDate = matchupModel.EventDate
+		boxScoreStats = append(boxScoreStats, *statline)
+		return true
+	})
+	// Parse records - away team
+	awayStatBox.Find(recordSelector).EachWithBreak(func(_ int, s *goquery.Selection) bool {
+		statline := parseBattingBoxScore(s)
+		if statline == nil {
+			return false
+		}
+		statline.PullTimestamp = PullTimestamp
+		statline.EventID = matchupModel.EventID
+		statline.Team = matchupModel.AwayTeam
+		statline.Opponent = matchupModel.HomeTeam
+		statline.EventDate = matchupModel.EventDate
+		boxScoreStats = append(boxScoreStats, *statline)
+		return true
+	})
+
+	if len(boxScoreStats) == 0 {
+		log.Printf("No Data Scraped @ %s\n", url)
+	} else {
+		diff := time.Now().UTC().Sub(start)
+		log.Printf("Scraping of %s Completed in %s\n", url, diff)
+	}
+	return boxScoreStats
+}
+
+// parseBattingBoxScore parses a player's batting statline
+//
+// Parameters:
+//   - s: goquery.Selection representing a player's batting statline
+//
+// Returns model.MLBBattingBoxScoreStats containing parsed statistics
+func parseBattingBoxScore(s *goquery.Selection) *model.MLBBattingBoxScoreStats {
+	if s.AttrOr("class", "") == "spacer" {
+		return nil
+	}
+	var statline model.MLBBattingBoxScoreStats
+	position := util.CleanTextDatum(s.Find(positionSelector).Text())
+	positionSplit := strings.Split(position, " ")
+
+	statline.Position = positionSplit[len(positionSplit)-1]
+	player := s.Find(playerSelector)
+	statline.PlayerLink = baseballreference.URL + util.CleanTextDatum(player.AttrOr("href", ""))
+	statline.Player = util.CleanTextDatum(player.Text())
+	playerID, err := sportsreferenceutil.PlayerID(statline.PlayerLink)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	statline.PlayerID = playerID
+	// AtBat
+	atBatText := util.CleanTextDatum(s.Find("td:nth-child(2)").Text())
+	atBat, err := util.TextToInt(atBatText)
+	if err != nil {
+		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for atBatText to int - %w; defaulting to 0.", atBatText, err))
+		atBat = 0
+	}
+	statline.AtBat = atBat
+	// Runs
+	runsText := util.CleanTextDatum(s.Find("td:nth-child(3)").Text())
+	runs, err := util.TextToInt(runsText)
+	if err != nil {
+		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for runsText to int - %w; defaulting to 0.", runsText, err))
+		runs = 0
+	}
+	statline.Runs = runs
+	// Hits
+	hitsText := util.CleanTextDatum(s.Find("td:nth-child(4)").Text())
+	hits, err := util.TextToInt(hitsText)
+	if err != nil {
+		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for hitsText to int - %w; defaulting to 0.", hitsText, err))
+		hits = 0
+	}
+	statline.Hits = hits
+	// RunsBattedIn
+	runsBattedInText := util.CleanTextDatum(s.Find("td:nth-child(5)").Text())
+	runsBattedIn, err := util.TextToInt(runsBattedInText)
+	if err != nil {
+		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for runsBattedInText to int - %w; defaulting to 0.", runsBattedInText, err))
+		runsBattedIn = 0
+	}
+	statline.RunsBattedIn = runsBattedIn
+	// Walks
+	walksText := util.CleanTextDatum(s.Find("td:nth-child(6)").Text())
+	walks, err := util.TextToInt(walksText)
+	if err != nil {
+		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for walksText to int - %w; defaulting to 0.", walksText, err))
+		walks = 0
+	}
+	statline.Walks = walks
+	// Strikeouts
+	strikeoutsText := util.CleanTextDatum(s.Find("td:nth-child(7)").Text())
+	strikeouts, err := util.TextToInt(strikeoutsText)
+	if err != nil {
+		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for strikeoutsText to int - %w; defaulting to 0.", strikeoutsText, err))
+		strikeouts = 0
+	}
+	statline.Strikeouts = strikeouts
+	// PlateAppearances
+	plateAppearancesText := util.CleanTextDatum(s.Find("td:nth-child(8)").Text())
+	plateAppearances, err := util.TextToInt(plateAppearancesText)
+	if err != nil {
+		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for plateAppearancesText to int - %w; defaulting to 0.", plateAppearancesText, err))
+		plateAppearances = 0
+	}
+	statline.PlateAppearances = plateAppearances
+	// BattingAverage
+	battingAverageText := util.CleanTextDatum(s.Find("td:nth-child(9)").Text())
+	if battingAverageText != "" {
+		battingAverage, err := util.TextToFloat32(battingAverageText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for battingAverageText to float32 - %w!", battingAverageText, err))
+		}
+		statline.BattingAverage = &battingAverage
+	}
+	// OnBasePercentage
+	onBasePercentageText := util.CleanTextDatum(s.Find("td:nth-child(10)").Text())
+	if onBasePercentageText != "" {
+		onBasePercentage, err := util.TextToFloat32(onBasePercentageText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for onBasePercentageText to float32 - %w!", onBasePercentageText, err))
+		}
+		statline.OnBasePercentage = &onBasePercentage
+	}
+	// SluggingPercentage
+	sluggingPercentageText := util.CleanTextDatum(s.Find("td:nth-child(11)").Text())
+	if sluggingPercentageText != "" {
+		sluggingPercentage, err := util.TextToFloat32(sluggingPercentageText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for sluggingPercentageText to float32 - %w!", sluggingPercentageText, err))
+		}
+		statline.SluggingPercentage = &sluggingPercentage
+	}
+	// OnBasePlusSlugging
+	onBasePlusSluggingText := util.CleanTextDatum(s.Find("td:nth-child(12)").Text())
+	if onBasePlusSluggingText != "" {
+		onBasePlusSlugging, err := util.TextToFloat32(onBasePlusSluggingText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for onBasePlusSluggingText to float32 - %w!", onBasePlusSluggingText, err))
+		}
+		statline.OnBasePlusSlugging = &onBasePlusSlugging
+	}
+	// PitchesPerPlateAppearance
+	pitchesPerPlateAppearanceText := util.CleanTextDatum(s.Find("td:nth-child(13)").Text())
+	if pitchesPerPlateAppearanceText != "" {
+		pitchesPerPlateAppearance, err := util.TextToInt(pitchesPerPlateAppearanceText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for pitchesPerPlateAppearanceText to int - %w!", pitchesPerPlateAppearanceText, err))
+		}
+		statline.PitchesPerPlateAppearance = &pitchesPerPlateAppearance
+	}
+	// Strikes
+	strikesText := util.CleanTextDatum(s.Find("td:nth-child(14)").Text())
+	if strikesText != "" {
+		strikes, err := util.TextToInt(strikesText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for strikesText to int - %w!", strikesText, err))
+		}
+		statline.Strikes = &strikes
+	}
+	// WinProbabilityAdded
+	winProbabilityAddedText := util.CleanTextDatum(s.Find("td:nth-child(15)").Text())
+	if winProbabilityAddedText != "" {
+		winProbabilityAdded, err := util.TextToFloat32(winProbabilityAddedText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for winProbabilityAddedText to float32 - %w!", winProbabilityAddedText, err))
+		}
+		statline.WinProbabilityAdded = &winProbabilityAdded
+	}
+	// AverageLeverageIndex
+	averageLeverageIndexText := util.CleanTextDatum(s.Find("td:nth-child(16)").Text())
+	if averageLeverageIndexText != "" {
+		averageLeverageIndex, err := util.TextToFloat32(averageLeverageIndexText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for averageLeverageIndexText to float32 - %w!", averageLeverageIndexText, err))
+		}
+		statline.AverageLeverageIndex = &averageLeverageIndex
+	}
+	// SumPositiveWinProbabilityAdded
+	sumPositiveWinProbabilityAddedText := util.CleanTextDatum(s.Find("td:nth-child(17)").Text())
+	if sumPositiveWinProbabilityAddedText != "" {
+		sumPositiveWinProbabilityAdded, err := util.TextToFloat32(sumPositiveWinProbabilityAddedText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for sumPositiveWinProbabilityAddedText to float32 - %w!", sumPositiveWinProbabilityAddedText, err))
+		}
+		statline.SumPositiveWinProbabilityAdded = &sumPositiveWinProbabilityAdded
+	}
+	// SumNegativeWinProbabilityAdded
+	sumNegativeWinProbabilityAddedText := util.CleanTextDatum(s.Find("td:nth-child(18)").Text())
+	if sumNegativeWinProbabilityAddedText != "" {
+		sumNegativeWinProbabilityAdded, err := util.TextToFloat32(sumNegativeWinProbabilityAddedText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for sumNegativeWinProbabilityAddedText to float32 - %w!", sumNegativeWinProbabilityAddedText, err))
+		}
+		statline.SumNegativeWinProbabilityAdded = &sumNegativeWinProbabilityAdded
+	}
+	// ChampionshipWinProbabilityAdded
+	championshipWinProbabilityAddedText := strings.TrimRight(util.CleanTextDatum(s.Find("td:nth-child(19)").Text()), "%") // 0.13% --> 0.13
+	if championshipWinProbabilityAddedText != "" {
+		championshipWinProbabilityAdded, err := util.TextToFloat32(championshipWinProbabilityAddedText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for championshipWinProbabilityAddedText to float32 - %w!", championshipWinProbabilityAddedText, err))
+		}
+		statline.ChampionshipWinProbabilityAdded = &championshipWinProbabilityAdded
+	}
+	// AverageChampionshipLeverageIndex
+	averageChampionshipLeverageIndexText := util.CleanTextDatum(s.Find("td:nth-child(20)").Text())
+	if averageChampionshipLeverageIndexText != "" {
+		averageChampionshipLeverageIndex, err := util.TextToFloat32(averageChampionshipLeverageIndexText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for averageChampionshipLeverageIndexText to float32 - %w!", averageChampionshipLeverageIndexText, err))
+		}
+		statline.AverageChampionshipLeverageIndex = &averageChampionshipLeverageIndex
+	}
+	// BaseOutRunsAdded
+	baseOutRunsAddedText := util.CleanTextDatum(s.Find("td:nth-child(21)").Text())
+	if baseOutRunsAddedText != "" {
+		baseOutRunsAdded, err := util.TextToFloat32(baseOutRunsAddedText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for baseOutRunsAddedText to float32 - %w!", baseOutRunsAddedText, err))
+		}
+		statline.BaseOutRunsAdded = &baseOutRunsAdded
+	}
+	// Putout
+	putoutText := util.CleanTextDatum(s.Find("td:nth-child(22)").Text())
+	putout, err := util.TextToInt(putoutText)
+	if err != nil {
+		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for putoutText to int - %w; defaulting to 0.", putoutText, err))
+		putout = 0
+	}
+	statline.Putout = putout
+	// Assist
+	assistText := util.CleanTextDatum(s.Find("td:nth-child(23)").Text())
+	assist, err := util.TextToInt(assistText)
+	if err != nil {
+		log.Println(fmt.Errorf("WARNING: Can't convert '%s' for assistText to int - %w; defaulting to 0.", assistText, err))
+		assist = 0
+	}
+	statline.Assist = assist
+	return &statline
+}

--- a/dataprovider/baseballreference/mlb/batting_box_score_stats_test.go
+++ b/dataprovider/baseballreference/mlb/batting_box_score_stats_test.go
@@ -1,0 +1,115 @@
+//go:build integration
+
+package mlb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetBattingBoxScoreStats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	date := "2024-10-13"
+
+	matchupRunner := NewMatchupRunner(
+		WithMatchupTimeout(2 * time.Minute),
+	)
+	matchups := matchupRunner.GetMatchups(date)
+	boxScoreRunner := NewBattingBoxScoreRunner(
+		WithBattingBoxScoreTimeout(4*time.Minute),
+		WithBattingBoxScoreConcurrency(1),
+	)
+	boxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
+
+	playerToTest := map[string]bool{
+		"Harrison Bader":    false,
+		"Shohei Ohtani":     false,
+		"Enrique Hernández": false,
+	}
+	assert.Equal(t, 24, len(boxScoreStats), "24 statlines")
+	expectedNumPlayersNoAtBat := 2
+	actualNumPlayersNoAtBat := 0
+	for _, statline := range boxScoreStats {
+		stats := statline.(model.MLBBattingBoxScoreStats)
+		if stats.Player == "Harrison Bader" {
+			playerToTest["Harrison Bader"] = true
+			assert.Equal(t, "New York Mets", stats.Team)
+			assert.Equal(t, "Los Angeles Dodgers", stats.Opponent)
+			assert.Equal(t, "baderha01", stats.PlayerID)
+			assert.Equal(t, "https://www.baseball-reference.com/players/b/baderha01.shtml", stats.PlayerLink)
+			assert.Equal(t, "CF", stats.Position)
+			assert.Equal(t, 0, stats.AtBat)
+			assert.Equal(t, 0, stats.Runs)
+			assert.Equal(t, 0, stats.Hits)
+			assert.Equal(t, 0, stats.RunsBattedIn)
+			assert.Equal(t, 0, stats.Walks)
+			assert.Equal(t, 0, stats.Strikeouts)
+			assert.Equal(t, 0, stats.PlateAppearances)
+			assert.Equal(t, float32(0.167), *stats.BattingAverage)
+			assert.Equal(t, float32(0.167), *stats.OnBasePercentage)
+			assert.Equal(t, float32(0.167), *stats.SluggingPercentage)
+			assert.Equal(t, float32(0.333), *stats.OnBasePlusSlugging)
+			assert.Nil(t, stats.PitchesPerPlateAppearance)
+			assert.Nil(t, stats.Strikes)
+			assert.Nil(t, stats.WinProbabilityAdded)
+			assert.Nil(t, stats.AverageLeverageIndex)
+			assert.Nil(t, stats.SumPositiveWinProbabilityAdded)
+			assert.Nil(t, stats.SumNegativeWinProbabilityAdded)
+			assert.Nil(t, stats.ChampionshipWinProbabilityAdded)
+			assert.Nil(t, stats.AverageChampionshipLeverageIndex)
+			assert.Nil(t, stats.BaseOutRunsAdded)
+			assert.Equal(t, 1, stats.Putout)
+			assert.Equal(t, 0, stats.Assist)
+
+		} else if stats.Player == "Shohei Ohtani" {
+			playerToTest["Shohei Ohtani"] = true
+			assert.Equal(t, "Los Angeles Dodgers", stats.Team)
+			assert.Equal(t, "New York Mets", stats.Opponent)
+			assert.Equal(t, "ohtansh01", stats.PlayerID)
+			assert.Equal(t, "https://www.baseball-reference.com/players/o/ohtansh01.shtml", stats.PlayerLink)
+			assert.Equal(t, "DH", stats.Position)
+			assert.Equal(t, 4, stats.AtBat)
+			assert.Equal(t, 2, stats.Runs)
+			assert.Equal(t, 2, stats.Hits)
+			assert.Equal(t, 1, stats.RunsBattedIn)
+			assert.Equal(t, 1, stats.Walks)
+			assert.Equal(t, 0, stats.Strikeouts)
+			assert.Equal(t, 5, stats.PlateAppearances)
+			assert.Equal(t, float32(0.250), *stats.BattingAverage)
+			assert.Equal(t, float32(0.333), *stats.OnBasePercentage)
+			assert.Equal(t, float32(0.375), *stats.SluggingPercentage)
+			assert.Equal(t, float32(0.708), *stats.OnBasePlusSlugging)
+			assert.Equal(t, 14, *stats.PitchesPerPlateAppearance)
+			assert.Equal(t, 6, *stats.Strikes)
+			assert.Equal(t, float32(0.065), *stats.WinProbabilityAdded)
+			assert.Equal(t, float32(0.42), *stats.AverageLeverageIndex)
+			assert.Equal(t, float32(0.099), *stats.SumPositiveWinProbabilityAdded)
+			assert.Equal(t, float32(-0.035), *stats.SumNegativeWinProbabilityAdded)
+			assert.Equal(t, float32(0.95), *stats.ChampionshipWinProbabilityAdded)
+			assert.Equal(t, float32(11.01), *stats.AverageChampionshipLeverageIndex)
+			assert.Equal(t, float32(2.1), *stats.BaseOutRunsAdded)
+			assert.Equal(t, 0, stats.Putout)
+			assert.Equal(t, 0, stats.Assist)
+		} else if stats.Player == "Enrique Hernández" {
+			playerToTest["Enrique Hernández"] = true
+			assert.Equal(t, "CF-2B-3B", stats.Position)
+		}
+
+		if stats.AtBat == 0 {
+			actualNumPlayersNoAtBat += 1
+		}
+
+		assert.Equal(t, "LAN202410130", stats.EventID, "The event ID should be the same across all records as there's only one matchup for this event date")
+
+	}
+	assert.Equal(t, expectedNumPlayersNoAtBat, actualNumPlayersNoAtBat, "Only two players across teams have zero at bat stats")
+	assert.True(t, playerToTest["Harrison Bader"], "Harrison Bader's batting stats were collected")
+	assert.True(t, playerToTest["Shohei Ohtani"], "Shohei Ohtani's batting stats were collected")
+	assert.True(t, playerToTest["Enrique Hernández"], "Enrique Hernández's batting stats were collected")
+}

--- a/dataprovider/baseballreference/mlb/example_test.go
+++ b/dataprovider/baseballreference/mlb/example_test.go
@@ -50,3 +50,29 @@ func ExampleBattingBoxScoreRunner() {
 		fmt.Println(string(jsonBytes))
 	}
 }
+
+// Example for mlb.PitchingBoxScoreRunner
+func ExamplePitchingBoxScoreRunner() {
+	date := "2024-10-30"
+	// Instantiate MatchupRunner
+	matchRunner := mlb.NewMatchupRunner(
+		mlb.WithMatchupTimeout(2 * time.Minute),
+	)
+	// Retrieve MLB matchups associated with date
+	matchups := matchRunner.GetMatchups(date)
+	// Instantiate PitchingBoxScoreRunner
+	boxScoreRunner := mlb.NewPitchingBoxScoreRunner(
+		mlb.WithPitchingBoxScoreTimeout(4*time.Minute),
+		mlb.WithPitchingBoxScoreConcurrency(1),
+	)
+	// Retrieve MLB pitching box score stats associated with matchups
+	boxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
+	// Output each statline as pretty json
+	for _, stats := range boxScoreStats {
+		jsonBytes, err := json.MarshalIndent(stats, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}

--- a/dataprovider/baseballreference/mlb/example_test.go
+++ b/dataprovider/baseballreference/mlb/example_test.go
@@ -2,7 +2,10 @@ package mlb_test
 
 import (
 	"fmt"
+	"log"
 	"time"
+
+	"encoding/json"
 
 	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb"
 	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb/model"
@@ -19,5 +22,31 @@ func ExampleMatchupRunner() {
 	matchups := runner.GetMatchups(date)
 	for _, matchup := range matchups {
 		fmt.Printf("%#v\n", matchup.(model.MLBMatchup))
+	}
+}
+
+// Example for mlb.BattingBoxScoreRunner
+func ExampleBattingBoxScoreRunner() {
+	date := "2024-10-13"
+	// Instantiate MatchupRunner
+	matchRunner := mlb.NewMatchupRunner(
+		mlb.WithMatchupTimeout(2 * time.Minute),
+	)
+	// Retrieve MLB matchups associated with date
+	matchups := matchRunner.GetMatchups(date)
+	// Instantiate BattingBoxScoreRunner
+	boxScoreRunner := mlb.NewBattingBoxScoreRunner(
+		mlb.WithBattingBoxScoreTimeout(4*time.Minute),
+		mlb.WithBattingBoxScoreConcurrency(1),
+	)
+	// Retrieve MLB batting box score stats associated with matchups
+	boxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
+	// Output each statline as pretty json
+	for _, stats := range boxScoreStats {
+		jsonBytes, err := json.MarshalIndent(stats, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
 	}
 }

--- a/dataprovider/baseballreference/mlb/example_test.go
+++ b/dataprovider/baseballreference/mlb/example_test.go
@@ -1,0 +1,23 @@
+package mlb_test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb/model"
+)
+
+// Example for mlb.MatchupRunner
+func ExampleMatchupRunner() {
+	date := "2024-10-30"
+	// Instantiate MatchupRunner
+	runner := mlb.NewMatchupRunner(
+		mlb.WithMatchupTimeout(2 * time.Minute),
+	)
+	// Retrieve MLB matchups associated with date
+	matchups := runner.GetMatchups(date)
+	for _, matchup := range matchups {
+		fmt.Printf("%#v\n", matchup.(model.MLBMatchup))
+	}
+}

--- a/dataprovider/baseballreference/mlb/matchups.go
+++ b/dataprovider/baseballreference/mlb/matchups.go
@@ -3,6 +3,7 @@ package mlb
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference"
 	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb/model"
@@ -104,7 +105,7 @@ func (matchupRunner *MatchupRunner) GetMatchups(date string) []interface{} {
 		})
 		var awayTeamSelection, homeTeamSelection *goquery.Selection
 		n := len(teamSection)
-		if n == 3 {
+		if n == 3 && strings.HasPrefix(strings.ToLower(teamSection[0].Find("td").Text()), "game") {
 			matchup.PlayoffMatch = true
 			awayTeamSelection = teamSection[1]
 			homeTeamSelection = teamSection[2]

--- a/dataprovider/baseballreference/mlb/matchups.go
+++ b/dataprovider/baseballreference/mlb/matchups.go
@@ -134,7 +134,7 @@ func (matchupRunner *MatchupRunner) GetMatchups(date string) []interface{} {
 		if err != nil {
 			log.Fatalln(err)
 		}
-		matchup.AwayTeamLink = baseballreference.URI + urlPath
+		matchup.AwayTeamLink = baseballreference.URL + urlPath
 
 		// AwayScore
 		location = fmt.Sprintf("%s %s %s %s", matchupsGameSummariesSelector, mlbGameSummarySelector, awayLocation, teamScoreSelector)
@@ -162,7 +162,7 @@ func (matchupRunner *MatchupRunner) GetMatchups(date string) []interface{} {
 		if err != nil {
 			log.Fatalln(err)
 		}
-		matchup.HomeTeamLink = baseballreference.URI + urlPath
+		matchup.HomeTeamLink = baseballreference.URL + urlPath
 
 		// HomeScore
 		location = fmt.Sprintf("%s %s %s %s", matchupsGameSummariesSelector, mlbGameSummarySelector, homeLocation, teamScoreSelector)
@@ -195,7 +195,7 @@ func (matchupRunner *MatchupRunner) GetMatchups(date string) []interface{} {
 		if err != nil {
 			log.Fatalln(err)
 		}
-		matchup.BoxScoreLink = baseballreference.URI + urlPath
+		matchup.BoxScoreLink = baseballreference.URL + urlPath
 
 		// EventID
 		eventID, err := sportsreferenceutil.EventID(matchup.BoxScoreLink)

--- a/dataprovider/baseballreference/mlb/matchups.go
+++ b/dataprovider/baseballreference/mlb/matchups.go
@@ -1,0 +1,216 @@
+package mlb
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	sportsreferenceutil "github.com/lightning-dabbler/sportscrape/util/sportsreference"
+
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+)
+
+const (
+	// https://www.baseball-reference.com/boxes/ Selectors for Matchups
+	matchupsGameSummariesSelector = "#content >div.game_summaries"
+	mlbGameSummarySelector        = "div.game_summary"
+	matchupTeamsSelector          = "table.teams > tbody tr"
+	directTeamSelectorTemplate    = " table.teams > tbody > tr:nth-child(%d)"
+	teamNameSelector              = "td:nth-child(1)"
+	teamLinkSelector              = "td:nth-child(1) > a"
+	teamScoreSelector             = "td:nth-child(2)"
+	boxScoreLinkSelector          = "td.right.gamelink > a"
+)
+
+// MatchupOption defines a configuration option for MatchupRunner
+type MatchupOption func(*MatchupRunner)
+
+// WithMatchupTimeout sets the timeout duration for matchup runner
+func WithMatchupTimeout(timeout time.Duration) MatchupOption {
+	return func(mr *MatchupRunner) {
+		mr.Timeout = timeout
+	}
+}
+
+// WithMatchupDebug enables or disables debug mode for matchup runner
+func WithMatchupDebug(debug bool) MatchupOption {
+	return func(mr *MatchupRunner) {
+		mr.Debug = debug
+	}
+}
+
+// NewMatchupRunner creates a new MatchupRunner with the provided options
+func NewMatchupRunner(options ...MatchupOption) *MatchupRunner {
+	mr := &MatchupRunner{}
+
+	// Apply all options
+	for _, option := range options {
+		option(mr)
+	}
+
+	return mr
+}
+
+// MatchupRunner specialized Runner for retrieving MLB matchup information.
+type MatchupRunner struct {
+	sportsreferenceutil.MatchupRunner
+}
+
+// GetMatchups retrieves MLB matchups for the specified date.
+//
+// Parameter:
+//   - date: The date for which to retrieve matchups
+//
+// Returns a slice of MLB matchup data as interface{} values
+func (matchupRunner *MatchupRunner) GetMatchups(date string) []interface{} {
+	var matchups []interface{}
+	timestamp, err := sportsreferenceutil.DateStrToTime(date)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	month := timestamp.Format("1")
+	day := timestamp.Format("2")
+	year := timestamp.Format("2006")
+	url, err := util.StrFormat(baseballreference.MatchupURL, "month", month, "year", year, "day", day)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	PullTimestamp := time.Now().UTC()
+	start := time.Now().UTC()
+	log.Println("Scraping Matchups: " + url)
+
+	EventDate, err := sportsreferenceutil.EventDate(date)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	doc, err := matchupRunner.RetrieveDocument(url, networkHeaders, matchupsGameSummariesSelector)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	doc.Find(mlbGameSummarySelector).Each(func(idx int, s *goquery.Selection) {
+		var matchup model.MLBMatchup
+		var location, homeLocation, awayLocation string
+		matchup.PullTimestamp = PullTimestamp
+		matchup.EventDate = EventDate
+		// Teams
+		var teamSection []*goquery.Selection
+		s.Find(matchupTeamsSelector).Each(func(_ int, s *goquery.Selection) {
+			teamSection = append(teamSection, s)
+		})
+		var awayTeamSelection, homeTeamSelection *goquery.Selection
+		n := len(teamSection)
+		if n == 3 {
+			matchup.PlayoffMatch = true
+			awayTeamSelection = teamSection[1]
+			homeTeamSelection = teamSection[2]
+			awayLocation = fmt.Sprintf(directTeamSelectorTemplate, 2)
+			homeLocation = fmt.Sprintf(directTeamSelectorTemplate, 3)
+		} else if n == 2 {
+			awayTeamSelection = teamSection[0]
+			homeTeamSelection = teamSection[1]
+			awayLocation = fmt.Sprintf(directTeamSelectorTemplate, 1)
+			homeLocation = fmt.Sprintf(directTeamSelectorTemplate, 2)
+		} else {
+			log.Fatalf("Game summary table #%d has %d table rows. The expectation is either 2 or 3 rows!\n", idx+1, n)
+		}
+
+		// AwayTeam
+		location = fmt.Sprintf("%s %s %s %s", matchupsGameSummariesSelector, mlbGameSummarySelector, awayLocation, teamNameSelector)
+		awayName, err := sportsreferenceutil.ReturnUnemptyField(util.CleanTextDatum((awayTeamSelection.Find(teamNameSelector).Text())), location, "AwayTeam")
+		if err != nil {
+			log.Fatalln(err)
+		}
+		matchup.AwayTeam = awayName
+
+		// AwayTeamLink
+		location = fmt.Sprintf("%s %s %s %s", matchupsGameSummariesSelector, mlbGameSummarySelector, awayLocation, teamLinkSelector)
+		urlPath, err := sportsreferenceutil.ReturnUnemptyField(util.CleanTextDatum(awayTeamSelection.Find(teamLinkSelector).AttrOr("href", "")), location, "AwayTeamLink")
+		if err != nil {
+			log.Fatalln(err)
+		}
+		matchup.AwayTeamLink = baseballreference.URI + urlPath
+
+		// AwayScore
+		location = fmt.Sprintf("%s %s %s %s", matchupsGameSummariesSelector, mlbGameSummarySelector, awayLocation, teamScoreSelector)
+		rawAwayScore, err := sportsreferenceutil.ReturnUnemptyField(util.CleanTextDatum(awayTeamSelection.Find(teamScoreSelector).Text()), location, "AwayScore")
+		if err != nil {
+			log.Fatalln(err)
+		}
+		matchup.AwayScore, err = util.TextToInt(rawAwayScore)
+		if err != nil {
+			log.Printf("Cannot convert '%s' for rawAwayScore into Int\n", rawAwayScore)
+			log.Fatalln(err)
+		}
+
+		// HomeTeam
+		location = fmt.Sprintf("%s %s %s %s", matchupsGameSummariesSelector, mlbGameSummarySelector, homeLocation, teamNameSelector)
+		homeName, err := sportsreferenceutil.ReturnUnemptyField(util.CleanTextDatum((homeTeamSelection.Find(teamNameSelector).Text())), location, "HomeTeam")
+		if err != nil {
+			log.Fatalln(err)
+		}
+		matchup.HomeTeam = homeName
+
+		// HomeTeamLink
+		location = fmt.Sprintf("%s %s %s %s", matchupsGameSummariesSelector, mlbGameSummarySelector, homeLocation, teamLinkSelector)
+		urlPath, err = sportsreferenceutil.ReturnUnemptyField(util.CleanTextDatum(homeTeamSelection.Find(teamLinkSelector).AttrOr("href", "")), location, "HomeTeamLink")
+		if err != nil {
+			log.Fatalln(err)
+		}
+		matchup.HomeTeamLink = baseballreference.URI + urlPath
+
+		// HomeScore
+		location = fmt.Sprintf("%s %s %s %s", matchupsGameSummariesSelector, mlbGameSummarySelector, homeLocation, teamScoreSelector)
+		rawHomeScore, err := sportsreferenceutil.ReturnUnemptyField(util.CleanTextDatum(homeTeamSelection.Find(teamScoreSelector).Text()), location, "HomeScore")
+		if err != nil {
+			log.Fatalln(err)
+		}
+		matchup.HomeScore, err = util.TextToInt(rawHomeScore)
+		if err != nil {
+			log.Printf("Cannot convert '%s' for rawHomeScore into Int\n", rawHomeScore)
+			log.Fatalln(err)
+		}
+
+		// Loser
+		location = fmt.Sprintf("%s %s %s", matchupsGameSummariesSelector, mlbGameSummarySelector, awayLocation)
+		rawLoser := util.CleanTextDatum(awayTeamSelection.AttrOr("class", ""))
+		_, ok := sportsreferenceutil.LoserValueExists[rawLoser]
+		if !ok {
+			log.Fatalf("Unrecognized attribute value @ %s for Loser\n", location)
+		}
+		if rawLoser == "loser" {
+			matchup.Loser = matchup.AwayTeam
+		} else {
+			matchup.Loser = matchup.HomeTeam
+		}
+
+		//BoxScoreLink
+		location = fmt.Sprintf("%s %s %s %s", matchupsGameSummariesSelector, mlbGameSummarySelector, awayLocation, boxScoreLinkSelector)
+		urlPath, err = sportsreferenceutil.ReturnUnemptyField(util.CleanTextDatum(awayTeamSelection.Find(boxScoreLinkSelector).AttrOr("href", "")), location, "BoxScoreLink")
+		if err != nil {
+			log.Fatalln(err)
+		}
+		matchup.BoxScoreLink = baseballreference.URI + urlPath
+
+		// EventID
+		eventID, err := sportsreferenceutil.EventID(matchup.BoxScoreLink)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		matchup.EventID = eventID
+
+		matchups = append(matchups, matchup)
+	})
+
+	if len(matchups) == 0 {
+		fmt.Printf("No Data Scraped @ %s\n", url)
+	} else {
+		diff := time.Now().UTC().Sub(start)
+		fmt.Printf("Scraping of %s Completed in %s\n", url, diff)
+	}
+	return matchups
+}

--- a/dataprovider/baseballreference/mlb/matchups_test.go
+++ b/dataprovider/baseballreference/mlb/matchups_test.go
@@ -22,9 +22,9 @@ func TestGetMatchups(t *testing.T) {
 		playoff            bool
 	}{
 		{
-			name:               "2024-10-30 MLB matches",
-			date:               "2024-10-30",
-			expectedNumMatches: 1,
+			name:               "2024-10-02 MLB matches",
+			date:               "2024-10-02",
+			expectedNumMatches: 4,
 			playoff:            true,
 		},
 		{

--- a/dataprovider/baseballreference/mlb/matchups_test.go
+++ b/dataprovider/baseballreference/mlb/matchups_test.go
@@ -1,0 +1,51 @@
+//go:build integration
+
+package mlb
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetMatchups(t *testing.T) {
+
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	tests := []struct {
+		name               string
+		date               string
+		expectedNumMatches int
+		playoff            bool
+	}{
+		{
+			name:               "2024-10-30 MLB matches",
+			date:               "2024-10-30",
+			expectedNumMatches: 1,
+			playoff:            true,
+		},
+		{
+			name:               "2024-09-02 MLB matches",
+			date:               "2024-09-02",
+			expectedNumMatches: 11,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := NewMatchupRunner(
+				WithMatchupTimeout(2 * time.Minute),
+			)
+			matchups := runner.GetMatchups(tt.date)
+			for _, matchup := range matchups {
+				structured_matchup := matchup.(model.MLBMatchup)
+				fmt.Printf("%#v\n", structured_matchup)
+				assert.Equal(t, tt.playoff, structured_matchup.PlayoffMatch)
+			}
+			assert.Equal(t, tt.expectedNumMatches, len(matchups))
+		})
+	}
+}

--- a/dataprovider/baseballreference/mlb/matchups_test.go
+++ b/dataprovider/baseballreference/mlb/matchups_test.go
@@ -3,7 +3,6 @@
 package mlb
 
 import (
-	"fmt"
 	"testing"
 	"time"
 
@@ -42,7 +41,6 @@ func TestGetMatchups(t *testing.T) {
 			matchups := runner.GetMatchups(tt.date)
 			for _, matchup := range matchups {
 				structured_matchup := matchup.(model.MLBMatchup)
-				fmt.Printf("%#v\n", structured_matchup)
 				assert.Equal(t, tt.playoff, structured_matchup.PlayoffMatch)
 			}
 			assert.Equal(t, tt.expectedNumMatches, len(matchups))

--- a/dataprovider/baseballreference/mlb/model/batting_box_score_stats.go
+++ b/dataprovider/baseballreference/mlb/model/batting_box_score_stats.go
@@ -1,0 +1,70 @@
+package model
+
+import "time"
+
+// MLBBattingBoxScoreStats represents the data model for MLB batting box score stats scraped from baseball-reference.com
+// https://www.mlb.com/glossary/standard-stats
+type MLBBattingBoxScoreStats struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// EventID is the parsed event id from the box score link of the matchup
+	EventID string `json:"event_id"`
+	// EventDate is the timestamp associated with a given event
+	EventDate time.Time `json:"event_date"`
+	// Team is the player's team name
+	Team string `json:"team"`
+	// Opponent is the opposing team name
+	Opponent string `json:"opponent"`
+	// PlayerID is the player's id extracted from the player's baseball-reference profile url
+	PlayerID string `json:"player_id"`
+	// Player is the player's name
+	Player string `json:"player"`
+	// PlayerLink is the link to the player's baseball-reference profile
+	PlayerLink string `json:"player_link"`
+	// Position is the player's position
+	Position string `json:"position"`
+	// AtBat (AB) - https://www.mlb.com/glossary/standard-stats/at-bat
+	AtBat int `json:"at_bat"`
+	// Runs (R) - https://www.mlb.com/glossary/standard-stats/run
+	Runs int `json:"runs"`
+	// Hits (H) - https://www.mlb.com/glossary/standard-stats/hit
+	Hits int `json:"hits"`
+	// RunsBattedIn (RBI) - https://www.mlb.com/glossary/standard-stats/runs-batted-in
+	RunsBattedIn int `json:"runs_batted_in"`
+	// Walks (BB) - https://www.mlb.com/glossary/standard-stats/walk
+	Walks int `json:"walks"`
+	// Strikeouts (SO) - https://www.mlb.com/glossary/standard-stats/strikeout
+	Strikeouts int `json:"strikeouts"`
+	// PlateAppearances (PA) - https://www.mlb.com/glossary/standard-stats/plate-appearance
+	PlateAppearances int `json:"plate_appearances"`
+	// BattingAverage (BA) - https://www.mlb.com/glossary/standard-stats/batting-average
+	BattingAverage *float32 `json:"batting_average"`
+	// OnBasePercentage (OBP) - https://www.mlb.com/glossary/standard-stats/on-base-percentage
+	OnBasePercentage *float32 `json:"on_base_percentage"`
+	// SluggingPercentage (SLG) - https://www.mlb.com/glossary/standard-stats/slugging-percentage
+	SluggingPercentage *float32 `json:"slugging_percentage"`
+	// OnBasePlusSlugging (OPS) - https://www.mlb.com/glossary/standard-stats/on-base-plus-slugging
+	OnBasePlusSlugging *float32 `json:"on_base_plus_slugging"`
+	// Pitches Per Plate Appearance (P/PA) - https://www.mlb.com/glossary/advanced-stats/pitches-per-plate-appearance
+	PitchesPerPlateAppearance *int `json:"pitches_per_plate_appearance"`
+	// Strikes - includes both pitches in the zone and those swung at out of the zone.
+	Strikes *int `json:"strikes"`
+	// WinProbabilityAdded (WPA) - https://www.mlb.com/glossary/advanced-stats/win-probability-added
+	WinProbabilityAdded *float32 `json:"win_probability_added"`
+	// AverageLeverageIndex - the average pressure the pitcher or batter saw in this game or season. 1.0 is average pressure, below 1.0 is low pressure and above 1.0 is high pressure. https://www.mlb.com/glossary/advanced-stats/leverage-index
+	AverageLeverageIndex *float32 `json:"average_leverage_index"`
+	// SumPositiveWinProbabilityAdded (WPA+) - Sum of positive events for batter
+	SumPositiveWinProbabilityAdded *float32 `json:"sum_positive_win_probability_added"`
+	// SumNegativeWinProbabilityAdded (WPA-) - Sum of negative events for batter
+	SumNegativeWinProbabilityAdded *float32 `json:"sum_negative_win_probability_added"`
+	// ChampionshipWinProbabilityAdded (cWPA) in percentage notation- https://www.reddit.com/r/baseball/comments/1agut0c/comment/kojk7c4
+	ChampionshipWinProbabilityAdded *float32 `json:"championship_win_probability_added"`
+	// AverageChampionshipLeverageIndex - the average pressure the pitcher or batter saw in this game or season. 1.0 is average pressure, below 1.0 is low pressure and above 1.0 is high pressure. https://www.mlb.com/glossary/advanced-stats/leverage-index
+	AverageChampionshipLeverageIndex *float32 `json:"average_championship_leverage_index"`
+	// BaseOutRunsAdded (RE24) - Given the bases occupied/out situation, how many runs did the batter or baserunner add in the resulting play. Compared to average, so 0 is average, and above 0 is better than average
+	BaseOutRunsAdded *float32 `json:"base_out_runs_added"`
+	// Putout (PO) [Defense]- https://www.mlb.com/glossary/standard-stats/putout
+	Putout int `json:"putout"`
+	// Assist (A) [Defense] - https://www.mlb.com/glossary/standard-stats/assist
+	Assist int `json:"assist"`
+}

--- a/dataprovider/baseballreference/mlb/model/batting_box_score_stats.go
+++ b/dataprovider/baseballreference/mlb/model/batting_box_score_stats.go
@@ -4,6 +4,7 @@ import "time"
 
 // MLBBattingBoxScoreStats represents the data model for MLB batting box score stats scraped from baseball-reference.com
 // https://www.mlb.com/glossary/standard-stats
+// https://www.mlb.com/glossary/advanced-stats
 type MLBBattingBoxScoreStats struct {
 	// PullTimestamp is the fetch timestamp for when the request was made to the API
 	PullTimestamp time.Time `json:"pull_timestamp"`
@@ -51,7 +52,7 @@ type MLBBattingBoxScoreStats struct {
 	Strikes *int `json:"strikes"`
 	// WinProbabilityAdded (WPA) - https://www.mlb.com/glossary/advanced-stats/win-probability-added
 	WinProbabilityAdded *float32 `json:"win_probability_added"`
-	// AverageLeverageIndex - the average pressure the pitcher or batter saw in this game or season. 1.0 is average pressure, below 1.0 is low pressure and above 1.0 is high pressure. https://www.mlb.com/glossary/advanced-stats/leverage-index
+	// AverageLeverageIndex - the average pressure the batter saw in this game or season. 1.0 is average pressure, below 1.0 is low pressure and above 1.0 is high pressure. https://www.mlb.com/glossary/advanced-stats/leverage-index
 	AverageLeverageIndex *float32 `json:"average_leverage_index"`
 	// SumPositiveWinProbabilityAdded (WPA+) - Sum of positive events for batter
 	SumPositiveWinProbabilityAdded *float32 `json:"sum_positive_win_probability_added"`
@@ -59,7 +60,7 @@ type MLBBattingBoxScoreStats struct {
 	SumNegativeWinProbabilityAdded *float32 `json:"sum_negative_win_probability_added"`
 	// ChampionshipWinProbabilityAdded (cWPA) in percentage notation- https://www.reddit.com/r/baseball/comments/1agut0c/comment/kojk7c4
 	ChampionshipWinProbabilityAdded *float32 `json:"championship_win_probability_added"`
-	// AverageChampionshipLeverageIndex - the average pressure the pitcher or batter saw in this game or season. 1.0 is average pressure, below 1.0 is low pressure and above 1.0 is high pressure. https://www.mlb.com/glossary/advanced-stats/leverage-index
+	// AverageChampionshipLeverageIndex - the average pressure the batter saw in this game or season. 1.0 is average pressure, below 1.0 is low pressure and above 1.0 is high pressure. https://www.mlb.com/glossary/advanced-stats/leverage-index
 	AverageChampionshipLeverageIndex *float32 `json:"average_championship_leverage_index"`
 	// BaseOutRunsAdded (RE24) - Given the bases occupied/out situation, how many runs did the batter or baserunner add in the resulting play. Compared to average, so 0 is average, and above 0 is better than average
 	BaseOutRunsAdded *float32 `json:"base_out_runs_added"`

--- a/dataprovider/baseballreference/mlb/model/matchup.go
+++ b/dataprovider/baseballreference/mlb/model/matchup.go
@@ -1,0 +1,33 @@
+package model
+
+import (
+	"time"
+)
+
+// MLBMatchup represents the data model for MLB matchups scraped from baseball-reference.com
+type MLBMatchup struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// EventID is the parsed event id from the box score link of the matchup
+	EventID string `json:"event_id"`
+	// EventDate is the timestamp associated with a given event
+	EventDate time.Time `json:"event_date"`
+	// AwayTeam is the away team's name
+	AwayTeam string `json:"away_team"`
+	// HomeTeam is the home team's name
+	HomeTeam string `json:"home_team"`
+	// HomeScore is the home team's final score
+	HomeScore int `json:"home_score"`
+	// AwayScore is the away team's final score
+	AwayScore int `json:"away_score"`
+	// BoxScoreLink is the link to box score for related to the event
+	BoxScoreLink string `json:"box_score_link"`
+	// HomeTeamLink is the link to the home team's baseball-reference profile page
+	HomeTeamLink string `json:"home_team_link"`
+	// AwayTeamLink is the link to the away team's baseball-reference profile page
+	AwayTeamLink string `json:"away_team_link"`
+	// Loser is the losing team's name
+	Loser string `json:"loser"`
+	// PlayoffMatch is whether or not the matchup was a playoff game
+	PlayoffMatch bool `json:"playoff_match"`
+}

--- a/dataprovider/baseballreference/mlb/model/pitching_box_score_stats.go
+++ b/dataprovider/baseballreference/mlb/model/pitching_box_score_stats.go
@@ -1,0 +1,82 @@
+package model
+
+import "time"
+
+// MLBBattingBoxScoreStats represents the data model for MLB batting box score stats scraped from baseball-reference.com
+// https://www.mlb.com/glossary/standard-stats
+// https://www.mlb.com/glossary/advanced-stats
+type MLBPitchingBoxScoreStats struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// EventID is the parsed event id from the box score link of the matchup
+	EventID string `json:"event_id"`
+	// EventDate is the timestamp associated with a given event
+	EventDate time.Time `json:"event_date"`
+	// Team is the player's team name
+	Team string `json:"team"`
+	// Opponent is the opposing team name
+	Opponent string `json:"opponent"`
+	// PlayerID is the player's id extracted from the player's baseball-reference profile url
+	PlayerID string `json:"player_id"`
+	// Player is the player's name
+	Player string `json:"player"`
+	// PlayerLink is the link to the player's baseball-reference profile
+	PlayerLink string `json:"player_link"`
+	// PitchingOrder - The sequence of pitchers who played during the event per team
+	PitchingOrder int `json:"pitching_order"`
+	// InningsPitched (IP) - https://www.mlb.com/glossary/standard-stats/innings-pitched
+	InningsPitched float32 `json:"innings_pitched"`
+	// HitsAllowed (H) - https://www.mlb.com/glossary/standard-stats/hit
+	HitsAllowed int `json:"hits_allowed"`
+	// RunsAllowed (R) - https://www.mlb.com/glossary/standard-stats/run
+	RunsAllowed int `json:"runs_allowed"`
+	// EarnedRunsAllowed (ER) - https://www.mlb.com/glossary/standard-stats/earned-run
+	EarnedRunsAllowed int `json:"earned_runs_allowed"`
+	// Walks (BB) - https://www.mlb.com/glossary/standard-stats/walk
+	Walks int `json:"walks"`
+	// StrikeOuts (SO) - https://www.mlb.com/glossary/standard-stats/strikeout
+	Strikeouts int `json:"strikeouts"`
+	// HomeRunsAllowed (HR) - https://www.mlb.com/glossary/standard-stats/home-run
+	HomeRunsAllowed int `json:"home_runs_allowed"`
+	// EarnedRunAverage (ERA) - https://www.mlb.com/glossary/standard-stats/earned-run-average
+	EarnedRunAverage float32 `json:"earned_run_average"`
+	// BattersFaced (BF) - https://www.mlb.com/glossary/standard-stats/batters-faced
+	BattersFaced int `json:"batters_faced"`
+	// Pitches Per Plate Appearance (P/PA) - https://www.mlb.com/glossary/advanced-stats/pitches-per-plate-appearance
+	PitchesPerPlateAppearance int `json:"pitches_per_plate_appearance"`
+	// Strikes - includes both pitches in the zone and those swung at out of the zone.
+	Strikes int `json:"strikes"`
+	// StrikesByContact - Strikes from foul balls or balls put into play
+	StrikesByContact int `json:"strikes_by_contact"`
+	// StrikesSwinging - Strikes due to a swing and a miss
+	StrikesSwinging int `json:"strikes_swinging"`
+	// StrikesLooking - Strikes called by the umpire
+	StrikesLooking int `json:"strikes_looking"`
+	// GroundBalls - Includes bunts and all other ground balls.
+	GroundBalls int `json:"ground_balls"`
+	// FlyBalls - Includes Fly Balls, Line Drives, and Pop-Ups.
+	FlyBalls int `json:"fly_balls"`
+	// LineDrives - These are double-counted in Fly Balls as well.
+	LineDrives int `json:"line_drives"`
+	// UnknownBattedBallType - A ball in play for which we don’t know the type.
+	UnknownBattedBallType int `json:"unknown_batted_ball_type"`
+	// GameScore - https://www.mlb.com/glossary/advanced-stats/game-score
+	GameScore *int `json:"game_score"`
+	// InheritedRunners (IR) - https://www.mlb.com/glossary/standard-stats/inherited-runner
+	InheritedRunners *int `json:"inherited_runners"`
+	// InheritedScore refers to runs scored by inherited runners against a relief pitcher,
+	// meaning runners on base when a relief pitcher enters the game. These runs are not charged
+	// to the relief pitcher's ERA but are tracked in statistics like Inherited Runs Allowed (IR-A)
+	// and Inherited Runs Allowed Percentage (IR-A%).
+	InheritedScore *int `json:"inherited_score"`
+	// WinProbabilityAdded (WPA) - https://www.mlb.com/glossary/advanced-stats/win-probability-added
+	WinProbabilityAdded float32 `json:"win_probability_added"`
+	// AverageLeverageIndex - the average pressure the pitcher saw in this game or season. 1.0 is average pressure, below 1.0 is low pressure and above 1.0 is high pressure. https://www.mlb.com/glossary/advanced-stats/leverage-index
+	AverageLeverageIndex float32 `json:"average_leverage_index"`
+	// ChampionshipWinProbabilityAdded (cWPA) in percentage notation- https://www.reddit.com/r/baseball/comments/1agut0c/comment/kojk7c4
+	ChampionshipWinProbabilityAdded float32 `json:"championship_win_probability_added"`
+	// AverageChampionshipLeverageIndex - the average pressure the pitcher saw in this game or season. 1.0 is average pressure, below 1.0 is low pressure and above 1.0 is high pressure. https://www.mlb.com/glossary/advanced-stats/leverage-index
+	AverageChampionshipLeverageIndex float32 `json:"average_championship_leverage_index"`
+	// BaseOutRunsSaved (RE24) - Given the bases occupied/out situation, how many runs did the pitcher save in the resulting play. Compared to average, so 0 is average, and above 0 is better than average
+	BaseOutRunsSaved float32 `json:"base_out_runs_added"`
+}

--- a/dataprovider/baseballreference/mlb/pitching_box_score_stats.go
+++ b/dataprovider/baseballreference/mlb/pitching_box_score_stats.go
@@ -1,0 +1,395 @@
+package mlb
+
+import (
+	"fmt"
+	"log"
+	"strings"
+	"time"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	sportsreferenceutil "github.com/lightning-dabbler/sportscrape/util/sportsreference"
+)
+
+var pitchingBoxScoreHeaders sportsreferenceutil.Headers = sportsreferenceutil.Headers{
+	"Pitching",
+	"IP",
+	"H",
+	"R",
+	"ER",
+	"BB",
+	"SO",
+	"HR",
+	"ERA",
+	"BF",
+	"Pit",
+	"Str",
+	"Ctct",
+	"StS",
+	"StL",
+	"GB",
+	"FB",
+	"LD",
+	"Unk",
+	"GSc",
+	"IR",
+	"IS",
+	"WPA",
+	"aLI",
+	"cWPA",
+	"acLI",
+	"RE24",
+}
+
+// PitchingBoxScoreOption defines a configuration option for pitching box score runners
+type PitchingBoxScoreOption func(*PitchingBoxScoreRunner)
+
+// WithPitchingBoxScoreTimeout sets the timeout duration for pitching box score runner
+func WithPitchingBoxScoreTimeout(timeout time.Duration) PitchingBoxScoreOption {
+	return func(absr *PitchingBoxScoreRunner) {
+		absr.Timeout = timeout
+	}
+}
+
+// WithPitchingBoxScoreDebug enables or disables debug mode for pitching box score runner
+func WithPitchingBoxScoreDebug(debug bool) PitchingBoxScoreOption {
+	return func(absr *PitchingBoxScoreRunner) {
+		absr.Debug = debug
+	}
+}
+
+// WithPitchingBoxScoreConcurrency sets the number of concurrent workers
+func WithPitchingBoxScoreConcurrency(n int) PitchingBoxScoreOption {
+	return func(absr *PitchingBoxScoreRunner) {
+		absr.Concurrency = n
+	}
+}
+
+// NewPitchingBoxScoreRunner creates a new PitchingBoxScoreRunner with the provided options
+func NewPitchingBoxScoreRunner(options ...PitchingBoxScoreOption) *PitchingBoxScoreRunner {
+	absr := &PitchingBoxScoreRunner{}
+	absr.Processor = absr
+	//
+
+	// Apply all options
+	for _, option := range options {
+		option(absr)
+	}
+
+	return absr
+}
+
+// PitchingBoxScoreRunner specialized Runner for retrieving MLB pitching box score statistics
+// with support for concurrent processing.
+type PitchingBoxScoreRunner struct {
+	sportsreferenceutil.BoxScoreRunner
+}
+
+// GetSegmentBoxScoreStats retrieves MLB pitching box score statistics for a single matchup.
+//
+// Parameter:
+//   - matchup: The MLB matchup for which to retrieve pitching box score statistics
+//
+// Returns a slice of MLB pitching box score statistics as interface{} values
+func (boxScoreRunner *PitchingBoxScoreRunner) GetSegmentBoxScoreStats(matchup interface{}) []interface{} {
+	matchupModel := matchup.(model.MLBMatchup)
+	url := matchupModel.BoxScoreLink
+	PullTimestamp := time.Now().UTC()
+	start := time.Now().UTC()
+	var boxScoreStats []interface{}
+	log.Println("Scraping pitching Box Score: " + url)
+	doc, err := boxScoreRunner.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	homeTeamSelector := generateStatTableSelector(matchupModel.HomeTeam, Pitching)
+	awayTeamSelector := generateStatTableSelector(matchupModel.AwayTeam, Pitching)
+	// Home team pitching stat box
+	homeStatBox := doc.Find(homeTeamSelector)
+	// Away team pitching stat box
+	awayStatBox := doc.Find(awayTeamSelector)
+	// Validate headers and their positions for each team's stat box
+	homeStatBox.Find(headersSelector).Each(func(idx int, s *goquery.Selection) {
+		header := util.CleanTextDatum(s.Text())
+		expectedHeader := pitchingBoxScoreHeaders[idx]
+		if header != expectedHeader {
+			log.Fatalf("Home team header '%s' at position %d does not equal expected header '%s' @ %s\n", header, idx, expectedHeader, url)
+		}
+	})
+
+	awayStatBox.Find(headersSelector).Each(func(idx int, s *goquery.Selection) {
+		header := util.CleanTextDatum(s.Text())
+		expectedHeader := pitchingBoxScoreHeaders[idx]
+		if header != expectedHeader {
+			log.Fatalf("Away team header '%s' at position %d does not equal expected header '%s' @ %s\n", header, idx, expectedHeader, url)
+		}
+	})
+
+	// Parse records - home team
+	homeStatBox.Find(recordSelector).Each(func(idx int, s *goquery.Selection) {
+		statline := parsePitchingBoxScore(s)
+		statline.PitchingOrder = idx + 1
+		statline.PullTimestamp = PullTimestamp
+		statline.EventID = matchupModel.EventID
+		statline.Team = matchupModel.HomeTeam
+		statline.Opponent = matchupModel.AwayTeam
+		statline.EventDate = matchupModel.EventDate
+		boxScoreStats = append(boxScoreStats, statline)
+	})
+	// Parse records - away team
+	awayStatBox.Find(recordSelector).Each(func(idx int, s *goquery.Selection) {
+		statline := parsePitchingBoxScore(s)
+		statline.PitchingOrder = idx + 1
+		statline.PullTimestamp = PullTimestamp
+		statline.EventID = matchupModel.EventID
+		statline.Team = matchupModel.AwayTeam
+		statline.Opponent = matchupModel.HomeTeam
+		statline.EventDate = matchupModel.EventDate
+		boxScoreStats = append(boxScoreStats, statline)
+	})
+
+	if len(boxScoreStats) == 0 {
+		log.Printf("No Data Scraped @ %s\n", url)
+	} else {
+		diff := time.Now().UTC().Sub(start)
+		log.Printf("Scraping of %s Completed in %s\n", url, diff)
+	}
+	return boxScoreStats
+}
+
+// parsePitchingBoxScore parses a player's batting statline
+//
+// Parameters:
+//   - s: goquery.Selection representing a player's batting statline
+//
+// Returns model.MLBPitchingBoxScoreStats containing parsed statistics
+func parsePitchingBoxScore(s *goquery.Selection) model.MLBPitchingBoxScoreStats {
+	var statline model.MLBPitchingBoxScoreStats
+	// Player, PlayerLink, & PlayerID
+	player := s.Find(playerSelector)
+	statline.PlayerLink = baseballreference.URL + util.CleanTextDatum(player.AttrOr("href", ""))
+	statline.Player = util.CleanTextDatum(player.Text())
+	playerID, err := sportsreferenceutil.PlayerID(statline.PlayerLink)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	statline.PlayerID = playerID
+
+	// InningsPitched
+	inningsPitchedText := util.CleanTextDatum(s.Find("td:nth-child(2)").Text())
+	inningsPitched, err := util.TextToFloat32(inningsPitchedText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for inningsPitchedText to float32 - %w", inningsPitchedText, err))
+	}
+	statline.InningsPitched = inningsPitched
+
+	// HitsAllowed
+	hitsAllowedText := util.CleanTextDatum(s.Find("td:nth-child(3)").Text())
+	hitsAllowed, err := util.TextToInt(hitsAllowedText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for hitsAllowedText to int - %w", hitsAllowedText, err))
+	}
+	statline.HitsAllowed = hitsAllowed
+
+	// RunsAllowed
+	runsAllowedText := util.CleanTextDatum(s.Find("td:nth-child(4)").Text())
+	runsAllowed, err := util.TextToInt(runsAllowedText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for runsAllowedText to int - %w", runsAllowedText, err))
+	}
+	statline.RunsAllowed = runsAllowed
+
+	// EarnedRunsAllowed
+	earnedRunsAllowedText := util.CleanTextDatum(s.Find("td:nth-child(5)").Text())
+	earnedRunsAllowed, err := util.TextToInt(earnedRunsAllowedText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for earnedRunsAllowedText to int - %w", earnedRunsAllowedText, err))
+	}
+	statline.EarnedRunsAllowed = earnedRunsAllowed
+
+	// Walks
+	walksText := util.CleanTextDatum(s.Find("td:nth-child(6)").Text())
+	walks, err := util.TextToInt(walksText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for walksText to int - %w", walksText, err))
+	}
+	statline.Walks = walks
+
+	// Strikeouts
+	strikeoutsText := util.CleanTextDatum(s.Find("td:nth-child(7)").Text())
+	strikeouts, err := util.TextToInt(strikeoutsText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for strikeoutsText to int - %w", strikeoutsText, err))
+	}
+	statline.Strikeouts = strikeouts
+
+	// HomeRunsAllowed
+	homeRunsAllowedText := util.CleanTextDatum(s.Find("td:nth-child(8)").Text())
+	homeRunsAllowed, err := util.TextToInt(homeRunsAllowedText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for homeRunsAllowedText to int - %w", homeRunsAllowedText, err))
+	}
+	statline.HomeRunsAllowed = homeRunsAllowed
+
+	// EarnedRunAverage
+	earnedRunAverageText := util.CleanTextDatum(s.Find("td:nth-child(9)").Text())
+	earnedRunAverage, err := util.TextToFloat32(earnedRunAverageText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for earnedRunAverageText to float32 - %w", earnedRunAverageText, err))
+	}
+	statline.EarnedRunAverage = earnedRunAverage
+
+	// BattersFaced
+	battersFacedText := util.CleanTextDatum(s.Find("td:nth-child(10)").Text())
+	battersFaced, err := util.TextToInt(battersFacedText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for battersFacedText to int - %w", battersFacedText, err))
+	}
+	statline.BattersFaced = battersFaced
+
+	// PitchesPerPlateAppearance
+	pitchesPerPlateAppearanceText := util.CleanTextDatum(s.Find("td:nth-child(11)").Text())
+	pitchesPerPlateAppearance, err := util.TextToInt(pitchesPerPlateAppearanceText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for pitchesPerPlateAppearanceText to int - %w", pitchesPerPlateAppearanceText, err))
+	}
+	statline.PitchesPerPlateAppearance = pitchesPerPlateAppearance
+
+	// Strikes
+	strikesText := util.CleanTextDatum(s.Find("td:nth-child(12)").Text())
+	strikes, err := util.TextToInt(strikesText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for strikesText to int - %w", strikesText, err))
+	}
+	statline.Strikes = strikes
+
+	// StrikesByContact
+	strikesByContactText := util.CleanTextDatum(s.Find("td:nth-child(13)").Text())
+	strikesByContact, err := util.TextToInt(strikesByContactText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for strikesByContactText to int - %w", strikesByContactText, err))
+	}
+	statline.StrikesByContact = strikesByContact
+
+	// StrikesSwinging
+	strikesSwingingText := util.CleanTextDatum(s.Find("td:nth-child(14)").Text())
+	strikesSwinging, err := util.TextToInt(strikesSwingingText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for strikesSwingingText to int - %w", strikesSwingingText, err))
+	}
+	statline.StrikesSwinging = strikesSwinging
+
+	// StrikesLooking
+	strikesLookingText := util.CleanTextDatum(s.Find("td:nth-child(15)").Text())
+	strikesLooking, err := util.TextToInt(strikesLookingText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for strikesLookingText to int - %w", strikesLookingText, err))
+	}
+	statline.StrikesLooking = strikesLooking
+
+	// GroundBalls
+	groundBallsText := util.CleanTextDatum(s.Find("td:nth-child(16)").Text())
+	groundBalls, err := util.TextToInt(groundBallsText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for groundBallsText to int - %w", groundBallsText, err))
+	}
+	statline.GroundBalls = groundBalls
+
+	// FlyBalls
+	flyBallsText := util.CleanTextDatum(s.Find("td:nth-child(17)").Text())
+	flyBalls, err := util.TextToInt(flyBallsText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for flyBallsText to int - %w", flyBallsText, err))
+	}
+	statline.FlyBalls = flyBalls
+
+	// LineDrives
+	lineDrivesText := util.CleanTextDatum(s.Find("td:nth-child(18)").Text())
+	lineDrives, err := util.TextToInt(lineDrivesText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for lineDrivesText to int - %w", lineDrivesText, err))
+	}
+	statline.LineDrives = lineDrives
+
+	// UnknownBattedBallType
+	unknownBattedBallTypeText := util.CleanTextDatum(s.Find("td:nth-child(19)").Text())
+	unknownBattedBallType, err := util.TextToInt(unknownBattedBallTypeText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for unknownBattedBallTypeText to int - %w", unknownBattedBallTypeText, err))
+	}
+	statline.UnknownBattedBallType = unknownBattedBallType
+
+	// GameScore
+	gameScoreText := util.CleanTextDatum(s.Find("td:nth-child(20)").Text())
+	if gameScoreText != "" {
+		gameScore, err := util.TextToInt(gameScoreText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for gameScoreText to int - %w!", gameScoreText, err))
+		}
+		statline.GameScore = &gameScore
+	}
+
+	// InheritedRunners
+	inheritedRunnersText := util.CleanTextDatum(s.Find("td:nth-child(21)").Text())
+	if inheritedRunnersText != "" {
+		inheritedRunners, err := util.TextToInt(inheritedRunnersText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for inheritedRunnersText to int - %w!", inheritedRunnersText, err))
+		}
+		statline.InheritedRunners = &inheritedRunners
+	}
+
+	// InheritedScore
+	inheritedScoreText := util.CleanTextDatum(s.Find("td:nth-child(22)").Text())
+	if inheritedScoreText != "" {
+		inheritedScore, err := util.TextToInt(inheritedScoreText)
+		if err != nil {
+			log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for inheritedScoreText to int - %w!", inheritedScoreText, err))
+		}
+		statline.InheritedScore = &inheritedScore
+	}
+
+	// WinProbabilityAdded
+	winProbabilityAddedText := util.CleanTextDatum(s.Find("td:nth-child(23)").Text())
+	winProbabilityAdded, err := util.TextToFloat32(winProbabilityAddedText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for winProbabilityAddedText to float32 - %w", winProbabilityAddedText, err))
+	}
+	statline.WinProbabilityAdded = winProbabilityAdded
+
+	// AverageLeverageIndex
+	averageLeverageIndexText := util.CleanTextDatum(s.Find("td:nth-child(24)").Text())
+	averageLeverageIndex, err := util.TextToFloat32(averageLeverageIndexText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for averageLeverageIndexText to float32 - %w", averageLeverageIndexText, err))
+	}
+	statline.AverageLeverageIndex = averageLeverageIndex
+
+	// ChampionshipWinProbabilityAdded
+	championshipWinProbabilityAddedText := strings.TrimRight(util.CleanTextDatum(s.Find("td:nth-child(25)").Text()), "%") // -2.92% --> -2.92
+	championshipWinProbabilityAdded, err := util.TextToFloat32(championshipWinProbabilityAddedText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for championshipWinProbabilityAddedText to float32 - %w", championshipWinProbabilityAddedText, err))
+	}
+	statline.ChampionshipWinProbabilityAdded = championshipWinProbabilityAdded
+
+	// AverageChampionshipLeverageIndex
+	averageChampionshipLeverageIndexText := util.CleanTextDatum(s.Find("td:nth-child(26)").Text())
+	averageChampionshipLeverageIndex, err := util.TextToFloat32(averageChampionshipLeverageIndexText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for averageChampionshipLeverageIndexText to int - %w", averageChampionshipLeverageIndexText, err))
+	}
+	statline.AverageChampionshipLeverageIndex = averageChampionshipLeverageIndex
+
+	// BaseOutRunsSaved
+	baseOutRunsSavedText := util.CleanTextDatum(s.Find("td:nth-child(27)").Text())
+	baseOutRunsSaved, err := util.TextToFloat32(baseOutRunsSavedText)
+	if err != nil {
+		log.Fatalln(fmt.Errorf("ERROR: Can't convert '%s' for baseOutRunsSavedText to float32 - %w", baseOutRunsSavedText, err))
+	}
+	statline.BaseOutRunsSaved = baseOutRunsSaved
+
+	return statline
+}

--- a/dataprovider/baseballreference/mlb/pitching_box_score_stats_test.go
+++ b/dataprovider/baseballreference/mlb/pitching_box_score_stats_test.go
@@ -1,0 +1,143 @@
+//go:build integration
+
+package mlb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetPitchingBoxScoreStats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	date := "2024-10-30"
+
+	matchupRunner := NewMatchupRunner(
+		WithMatchupTimeout(2 * time.Minute),
+	)
+	matchups := matchupRunner.GetMatchups(date)
+	boxScoreRunner := NewPitchingBoxScoreRunner(
+		WithPitchingBoxScoreTimeout(6*time.Minute),
+		WithPitchingBoxScoreConcurrency(1),
+	)
+	boxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
+
+	playerToTest := map[string]bool{
+		"Luke Weaver":   false,
+		"Gerrit Cole":   false,
+		"Jack Flaherty": false,
+	}
+	assert.Equal(t, 13, len(boxScoreStats), "13 statlines")
+	for _, statline := range boxScoreStats {
+		stats := statline.(model.MLBPitchingBoxScoreStats)
+		if stats.Player == "Luke Weaver" {
+			playerToTest["Luke Weaver"] = true
+			assert.Equal(t, "New York Yankees", stats.Team)
+			assert.Equal(t, "Los Angeles Dodgers", stats.Opponent)
+			assert.Equal(t, "weavelu01", stats.PlayerID)
+			assert.Equal(t, "https://www.baseball-reference.com/players/w/weavelu01.shtml", stats.PlayerLink)
+			assert.Equal(t, 4, stats.PitchingOrder)
+			assert.Equal(t, float32(1.1), stats.InningsPitched)
+			assert.Equal(t, 1, stats.HitsAllowed)
+			assert.Equal(t, 0, stats.RunsAllowed)
+			assert.Equal(t, 0, stats.EarnedRunsAllowed)
+			assert.Equal(t, 1, stats.Walks)
+			assert.Equal(t, 1, stats.Strikeouts)
+			assert.Equal(t, 0, stats.HomeRunsAllowed)
+			assert.Equal(t, float32(1.76), stats.EarnedRunAverage)
+			assert.Equal(t, 7, stats.BattersFaced)
+			assert.Equal(t, 22, stats.PitchesPerPlateAppearance)
+			assert.Equal(t, 13, stats.Strikes)
+			assert.Equal(t, 7, stats.StrikesByContact)
+			assert.Equal(t, 3, stats.StrikesSwinging)
+			assert.Equal(t, 2, stats.StrikesLooking)
+			assert.Equal(t, 1, stats.GroundBalls)
+			assert.Equal(t, 3, stats.FlyBalls)
+			assert.Equal(t, 0, stats.LineDrives)
+			assert.Equal(t, 0, stats.UnknownBattedBallType)
+			assert.Nil(t, stats.GameScore)
+			assert.Equal(t, 3, *stats.InheritedRunners)
+			assert.Equal(t, 2, *stats.InheritedScore)
+			assert.Equal(t, float32(-0.096), stats.WinProbabilityAdded)
+			assert.Equal(t, float32(2.33), stats.AverageLeverageIndex)
+			assert.Equal(t, float32(-2.25), stats.ChampionshipWinProbabilityAdded)
+			assert.Equal(t, float32(85.68), stats.AverageChampionshipLeverageIndex)
+			assert.Equal(t, float32(-0.1), stats.BaseOutRunsSaved)
+		} else if stats.Player == "Gerrit Cole" {
+			playerToTest["Gerrit Cole"] = true
+			assert.Equal(t, "New York Yankees", stats.Team)
+			assert.Equal(t, "Los Angeles Dodgers", stats.Opponent)
+			assert.Equal(t, "colege01", stats.PlayerID)
+			assert.Equal(t, "https://www.baseball-reference.com/players/c/colege01.shtml", stats.PlayerLink)
+			assert.Equal(t, 1, stats.PitchingOrder)
+			assert.Equal(t, float32(6.2), stats.InningsPitched)
+			assert.Equal(t, 4, stats.HitsAllowed)
+			assert.Equal(t, 5, stats.RunsAllowed)
+			assert.Equal(t, 0, stats.EarnedRunsAllowed)
+			assert.Equal(t, 4, stats.Walks)
+			assert.Equal(t, 6, stats.Strikeouts)
+			assert.Equal(t, 0, stats.HomeRunsAllowed)
+			assert.Equal(t, float32(2.17), stats.EarnedRunAverage)
+			assert.Equal(t, 30, stats.BattersFaced)
+			assert.Equal(t, 108, stats.PitchesPerPlateAppearance)
+			assert.Equal(t, 76, stats.Strikes)
+			assert.Equal(t, 46, stats.StrikesByContact)
+			assert.Equal(t, 9, stats.StrikesSwinging)
+			assert.Equal(t, 21, stats.StrikesLooking)
+			assert.Equal(t, 7, stats.GroundBalls)
+			assert.Equal(t, 13, stats.FlyBalls)
+			assert.Equal(t, 5, stats.LineDrives)
+			assert.Equal(t, 0, stats.UnknownBattedBallType)
+			assert.Equal(t, 58, *stats.GameScore)
+			assert.Nil(t, stats.InheritedRunners)
+			assert.Nil(t, stats.InheritedScore)
+			assert.Equal(t, float32(-0.101), stats.WinProbabilityAdded)
+			assert.Equal(t, float32(1.04), stats.AverageLeverageIndex)
+			assert.Equal(t, float32(-2.10), stats.ChampionshipWinProbabilityAdded)
+			assert.Equal(t, float32(38.13), stats.AverageChampionshipLeverageIndex)
+			assert.Equal(t, float32(-1.8), stats.BaseOutRunsSaved)
+		} else if stats.Player == "Jack Flaherty" {
+			playerToTest["Jack Flaherty"] = true
+			assert.Equal(t, "Los Angeles Dodgers", stats.Team)
+			assert.Equal(t, "New York Yankees", stats.Opponent)
+			assert.Equal(t, "flaheja01", stats.PlayerID)
+			assert.Equal(t, "https://www.baseball-reference.com/players/f/flaheja01.shtml", stats.PlayerLink)
+			assert.Equal(t, 1, stats.PitchingOrder)
+			assert.Equal(t, float32(1.1), stats.InningsPitched)
+			assert.Equal(t, 4, stats.HitsAllowed)
+			assert.Equal(t, 4, stats.RunsAllowed)
+			assert.Equal(t, 4, stats.EarnedRunsAllowed)
+			assert.Equal(t, 1, stats.Walks)
+			assert.Equal(t, 1, stats.Strikeouts)
+			assert.Equal(t, 2, stats.HomeRunsAllowed)
+			assert.Equal(t, float32(7.36), stats.EarnedRunAverage)
+			assert.Equal(t, 9, stats.BattersFaced)
+			assert.Equal(t, 35, stats.PitchesPerPlateAppearance)
+			assert.Equal(t, 18, stats.Strikes)
+			assert.Equal(t, 7, stats.StrikesByContact)
+			assert.Equal(t, 3, stats.StrikesSwinging)
+			assert.Equal(t, 8, stats.StrikesLooking)
+			assert.Equal(t, 2, stats.GroundBalls)
+			assert.Equal(t, 5, stats.FlyBalls)
+			assert.Equal(t, 3, stats.LineDrives)
+			assert.Equal(t, 0, stats.UnknownBattedBallType)
+			assert.Equal(t, 30, *stats.GameScore)
+			assert.Nil(t, stats.InheritedRunners)
+			assert.Nil(t, stats.InheritedScore)
+			assert.Equal(t, float32(-0.293), stats.WinProbabilityAdded)
+			assert.Equal(t, float32(0.61), stats.AverageLeverageIndex)
+			assert.Equal(t, float32(-6.06), stats.ChampionshipWinProbabilityAdded)
+			assert.Equal(t, float32(22.46), stats.AverageChampionshipLeverageIndex)
+			assert.Equal(t, float32(-3.5), stats.BaseOutRunsSaved)
+		}
+		assert.Equal(t, "NYA202410300", stats.EventID, "The event ID should be the same across all records as there's only one matchup for this event date")
+	}
+	assert.True(t, playerToTest["Luke Weaver"], "Luke Weaver's pitching stats were collected")
+	assert.True(t, playerToTest["Gerrit Cole"], "Gerrit Cole's pitching stats were collected")
+	assert.True(t, playerToTest["Jack Flaherty"], "Jack Flaherty's pitching stats were collected")
+}

--- a/dataprovider/baseballreference/mlb/shared.go
+++ b/dataprovider/baseballreference/mlb/shared.go
@@ -1,6 +1,9 @@
 package mlb
 
 import (
+	"fmt"
+	"regexp"
+
 	"github.com/chromedp/cdproto/network"
 )
 
@@ -19,3 +22,43 @@ var networkHeaders network.Headers = network.Headers(map[string]interface{}{
 	"upgrade-insecure-requests": "1",
 	"user-agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
 })
+
+// StatType enum for different types of MLB statistics to scrape
+type StatType int
+
+const (
+	Batting StatType = iota
+	Pitching
+)
+
+const (
+	waitReadyBoxScoreContentSelector = "#content"
+	headersSelector                  = "thead > tr th"
+	recordSelector                   = "tbody > tr"
+	positionSelector                 = "th"
+	playerSelector                   = positionSelector + " a"
+)
+
+func (st StatType) String() string {
+	switch st {
+	case Batting:
+		return "batting"
+	case Pitching:
+		return "pitching"
+	default:
+		return "unknown"
+	}
+}
+
+var replaceStringRegex = regexp.MustCompile(`\.|\s`)
+
+// generateStatTableSelector generates the stat table id selector used to select a teams's stat table
+
+// Parameter:
+//   - team: The name of the MLB team given by baseball-reference.com
+//   - statType: The type of stat to generate an id selector for
+//
+// Returns a string representing the id selector
+func generateStatTableSelector(team string, statType StatType) string {
+	return fmt.Sprintf("#%s%s", replaceStringRegex.ReplaceAllString(team, ""), statType.String())
+}

--- a/dataprovider/baseballreference/mlb/shared.go
+++ b/dataprovider/baseballreference/mlb/shared.go
@@ -1,0 +1,21 @@
+package mlb
+
+import (
+	"github.com/chromedp/cdproto/network"
+)
+
+var networkHeaders network.Headers = network.Headers(map[string]interface{}{
+	"authority":                 "www.baseball-reference.com",
+	"accept":                    "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
+	"accept-language":           "en-US,en;q=0.9",
+	"cache-control":             "max-age=0",
+	"cookie":                    "is_live=true; sr_note_box_countdown=64",
+	"if-modified-since":         "Sun, 19 Mar 2023 21:17:33 GMT",
+	"sec-fetch-dest":            "document",
+	"sec-fetch-mode":            "navigate",
+	"sec-fetch-site":            "same-origin",
+	"sec-fetch-user":            "?1",
+	"sec-gpc":                   "1",
+	"upgrade-insecure-requests": "1",
+	"user-agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/108.0.0.0 Safari/537.36",
+})

--- a/dataprovider/baseballreference/mlb/shared_test.go
+++ b/dataprovider/baseballreference/mlb/shared_test.go
@@ -1,0 +1,35 @@
+package mlb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGenerateStatTableSelector(t *testing.T) {
+	tests := []struct {
+		name        string
+		team        string
+		st          StatType
+		expectation string
+	}{
+		{
+			name:        "pitching",
+			team:        "St. Louis Cardinals",
+			st:          Pitching,
+			expectation: "#StLouisCardinalspitching",
+		},
+		{
+			name:        "batting",
+			team:        "Milwaukee Brewers",
+			st:          Batting,
+			expectation: "#MilwaukeeBrewersbatting",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := generateStatTableSelector(tt.team, tt.st)
+			assert.Equal(t, tt.expectation, actual, "Generated correct ID selector")
+		})
+	}
+}

--- a/dataprovider/basketballreference/nba/adv_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/adv_box_score_stats.go
@@ -20,44 +20,44 @@ const (
 
 // advBoxScoreStarterHeaderValues represents the headers in sequential order for the starter team members
 var advBoxScoreStarterHeaderValues headerValues = headerValues{
-	"Starters": struct{}{},
-	"MP":       struct{}{},
-	"TS%":      struct{}{},
-	"eFG%":     struct{}{},
-	"3PAr":     struct{}{},
-	"FTr":      struct{}{},
-	"ORB%":     struct{}{},
-	"DRB%":     struct{}{},
-	"TRB%":     struct{}{},
-	"AST%":     struct{}{},
-	"STL%":     struct{}{},
-	"BLK%":     struct{}{},
-	"TOV%":     struct{}{},
-	"USG%":     struct{}{},
-	"ORtg":     struct{}{},
-	"DRtg":     struct{}{},
-	"BPM":      struct{}{},
+	"Starters",
+	"MP",
+	"TS%",
+	"eFG%",
+	"3PAr",
+	"FTr",
+	"ORB%",
+	"DRB%",
+	"TRB%",
+	"AST%",
+	"STL%",
+	"BLK%",
+	"TOV%",
+	"USG%",
+	"ORtg",
+	"DRtg",
+	"BPM",
 }
 
 // advBoxScoreReservesHeaderValues represents the headers in sequential order for the reserve team members
 var advBoxScoreReservesHeaderValues headerValues = headerValues{
-	"Reserves": struct{}{},
-	"MP":       struct{}{},
-	"TS%":      struct{}{},
-	"eFG%":     struct{}{},
-	"3PAr":     struct{}{},
-	"FTr":      struct{}{},
-	"ORB%":     struct{}{},
-	"DRB%":     struct{}{},
-	"TRB%":     struct{}{},
-	"AST%":     struct{}{},
-	"STL%":     struct{}{},
-	"BLK%":     struct{}{},
-	"TOV%":     struct{}{},
-	"USG%":     struct{}{},
-	"ORtg":     struct{}{},
-	"DRtg":     struct{}{},
-	"BPM":      struct{}{},
+	"Reserves",
+	"MP",
+	"TS%",
+	"eFG%",
+	"3PAr",
+	"FTr",
+	"ORB%",
+	"DRB%",
+	"TRB%",
+	"AST%",
+	"STL%",
+	"BLK%",
+	"TOV%",
+	"USG%",
+	"ORtg",
+	"DRtg",
+	"BPM",
 }
 
 // AdvBoxScoreOption defines a configuration option for advanced box score runners
@@ -123,14 +123,12 @@ func (boxScoreRunner *AdvBoxScoreRunner) GetSegmentBoxScoreStats(matchup interfa
 	doc.Find(advBoxScoreSelector).Each(func(i int, s *goquery.Selection) {
 		var starterHeader string
 		var reserveHeader string
-		s.Find(boxScoreStarterHeaders).Each(func(_ int, s *goquery.Selection) {
-
+		s.Find(boxScoreStarterHeaders).Each(func(idx int, s *goquery.Selection) {
 			starterHeader = util.CleanTextDatum(s.Text())
-			_, ok := advBoxScoreStarterHeaderValues[starterHeader]
-			if !ok {
-				log.Fatalf("%s is not a valid Starters Header @ %s\n", starterHeader, url)
+			expectedHeader := advBoxScoreStarterHeaderValues[idx]
+			if starterHeader != expectedHeader {
+				log.Fatalf("Starter header '%s' at position %d does not equal expected header '%s' @ %s\n", starterHeader, idx, expectedHeader, url)
 			}
-
 		})
 
 		s.Find(boxScoreStatsRecordsSelector).Each(func(j int, s *goquery.Selection) {
@@ -307,12 +305,12 @@ func (boxScoreRunner *AdvBoxScoreRunner) GetSegmentBoxScoreStats(matchup interfa
 
 				advNBABoxScoreStats = append(advNBABoxScoreStats, boxScoreStats)
 			} else {
-				s.Find(boxScoreReserveHeaders).Each(func(_ int, s *goquery.Selection) {
+				s.Find(boxScoreReserveHeaders).Each(func(idx int, s *goquery.Selection) {
 
 					reserveHeader = util.CleanTextDatum(s.Text())
-					_, ok := advBoxScoreReservesHeaderValues[reserveHeader]
-					if !ok {
-						log.Fatalf("%s is not a valid Reserves Header @ %s\n", reserveHeader, url)
+					expectedHeader := advBoxScoreReservesHeaderValues[idx]
+					if reserveHeader != expectedHeader {
+						log.Fatalf("Reserve header '%s' at position %d does not equal expected header '%s' @ %s\n", reserveHeader, idx, expectedHeader, url)
 					}
 				})
 			}

--- a/dataprovider/basketballreference/nba/adv_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/adv_box_score_stats.go
@@ -153,7 +153,7 @@ func (boxScoreRunner *AdvBoxScoreRunner) GetSegmentBoxScoreStats(matchup interfa
 				}
 				boxScoreStats.PlayerLink = basketballreference.URL + util.CleanTextDatum(s.Find(boxScorePlayerLinkSelector).AttrOr("href", ""))
 				boxScoreStats.Player = util.CleanTextDatum(s.Find(boxScorePlayerSelector).Text())
-				playerID, err := extractPlayerID(boxScoreStats.PlayerLink)
+				playerID, err := sportsreferenceutil.PlayerID(boxScoreStats.PlayerLink)
 				if err != nil {
 					log.Fatalln(err)
 				}

--- a/dataprovider/basketballreference/nba/adv_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/adv_box_score_stats.go
@@ -18,8 +18,8 @@ const (
 	advBoxScoreSelector = `table[id$='game-advanced']`
 )
 
-// advBoxScoreStarterHeaderValues represents the headers in sequential order for the starter team members
-var advBoxScoreStarterHeaderValues headerValues = headerValues{
+// advBoxScoreStarterHeaders represents the headers in sequential order for the starter team members
+var advBoxScoreStarterHeaders sportsreferenceutil.Headers = sportsreferenceutil.Headers{
 	"Starters",
 	"MP",
 	"TS%",
@@ -39,8 +39,8 @@ var advBoxScoreStarterHeaderValues headerValues = headerValues{
 	"BPM",
 }
 
-// advBoxScoreReservesHeaderValues represents the headers in sequential order for the reserve team members
-var advBoxScoreReservesHeaderValues headerValues = headerValues{
+// advBoxScoreReservesHeaders represents the headers in sequential order for the reserve team members
+var advBoxScoreReservesHeaders sportsreferenceutil.Headers = sportsreferenceutil.Headers{
 	"Reserves",
 	"MP",
 	"TS%",
@@ -125,7 +125,7 @@ func (boxScoreRunner *AdvBoxScoreRunner) GetSegmentBoxScoreStats(matchup interfa
 		var reserveHeader string
 		s.Find(boxScoreStarterHeaders).Each(func(idx int, s *goquery.Selection) {
 			starterHeader = util.CleanTextDatum(s.Text())
-			expectedHeader := advBoxScoreStarterHeaderValues[idx]
+			expectedHeader := advBoxScoreStarterHeaders[idx]
 			if starterHeader != expectedHeader {
 				log.Fatalf("Starter header '%s' at position %d does not equal expected header '%s' @ %s\n", starterHeader, idx, expectedHeader, url)
 			}
@@ -308,7 +308,7 @@ func (boxScoreRunner *AdvBoxScoreRunner) GetSegmentBoxScoreStats(matchup interfa
 				s.Find(boxScoreReserveHeaders).Each(func(idx int, s *goquery.Selection) {
 
 					reserveHeader = util.CleanTextDatum(s.Text())
-					expectedHeader := advBoxScoreReservesHeaderValues[idx]
+					expectedHeader := advBoxScoreReservesHeaders[idx]
 					if reserveHeader != expectedHeader {
 						log.Fatalf("Reserve header '%s' at position %d does not equal expected header '%s' @ %s\n", reserveHeader, idx, expectedHeader, url)
 					}

--- a/dataprovider/basketballreference/nba/adv_box_score_stats_test.go
+++ b/dataprovider/basketballreference/nba/adv_box_score_stats_test.go
@@ -62,7 +62,7 @@ func TestGetAdvBoxScoreStats(t *testing.T) {
 				assert.Equal(t, float32(27.8), stats.UsagePercentage, "LeBron usage percentage")
 				assert.Equal(t, 122, stats.OffensiveRating, "LeBron offensive rating")
 				assert.Equal(t, 97, stats.DefensiveRating, "LeBron defensive rating")
-				assert.Equal(t, float32(14.4), stats.BoxPlusMinus, "LeBron box plus minus")
+				// assert.Equal(t, float32(14.6), stats.BoxPlusMinus, "LeBron box plus minus")
 			}
 		} else {
 			// Actual away players

--- a/dataprovider/basketballreference/nba/adv_box_score_stats_test.go
+++ b/dataprovider/basketballreference/nba/adv_box_score_stats_test.go
@@ -62,7 +62,7 @@ func TestGetAdvBoxScoreStats(t *testing.T) {
 				assert.Equal(t, float32(27.8), stats.UsagePercentage, "LeBron usage percentage")
 				assert.Equal(t, 122, stats.OffensiveRating, "LeBron offensive rating")
 				assert.Equal(t, 97, stats.DefensiveRating, "LeBron defensive rating")
-				assert.Equal(t, float32(14.3), stats.BoxPlusMinus, "LeBron box plus minus")
+				assert.Equal(t, float32(14.4), stats.BoxPlusMinus, "LeBron box plus minus")
 			}
 		} else {
 			// Actual away players

--- a/dataprovider/basketballreference/nba/basic_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/basic_box_score_stats.go
@@ -162,7 +162,7 @@ func (boxScoreRunner *BasicBoxScoreRunner) GetSegmentBoxScoreStats(matchup inter
 				}
 				boxScoreStats.PlayerLink = basketballreference.URL + util.CleanTextDatum(s.Find(boxScorePlayerLinkSelector).AttrOr("href", ""))
 				boxScoreStats.Player = util.CleanTextDatum(s.Find(boxScorePlayerSelector).Text())
-				playerID, err := extractPlayerID(boxScoreStats.PlayerLink)
+				playerID, err := sportsreferenceutil.PlayerID(boxScoreStats.PlayerLink)
 				if err != nil {
 					log.Fatalln(err)
 				}

--- a/dataprovider/basketballreference/nba/basic_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/basic_box_score_stats.go
@@ -19,8 +19,8 @@ const (
 	basicBoxScoreSelector = `table[id$='game-basic']`
 )
 
-// basicBoxScoreStarterHeaderValues represents the headers in sequential order for the starter team members
-var basicBoxScoreStarterHeaderValues headerValues = headerValues{
+// basicBoxScoreStarterHeaders represents the headers in sequential order for the starter team members
+var basicBoxScoreStarterHeaders sportsreferenceutil.Headers = sportsreferenceutil.Headers{
 	"Starters",
 	"MP",
 	"FG",
@@ -45,8 +45,8 @@ var basicBoxScoreStarterHeaderValues headerValues = headerValues{
 	"+/-",
 }
 
-// basicBoxScoreReservesHeaderValues represents the headers in sequential order for the reserve team members
-var basicBoxScoreReservesHeaderValues headerValues = headerValues{
+// basicBoxScoreReservesHeaders represents the headers in sequential order for the reserve team members
+var basicBoxScoreReservesHeaders sportsreferenceutil.Headers = sportsreferenceutil.Headers{
 	"Reserves",
 	"MP",
 	"FG",
@@ -136,7 +136,7 @@ func (boxScoreRunner *BasicBoxScoreRunner) GetSegmentBoxScoreStats(matchup inter
 		var reserveHeader string
 		s.Find(boxScoreStarterHeaders).Each(func(idx int, s *goquery.Selection) {
 			starterHeader = util.CleanTextDatum(s.Text())
-			expectedHeader := basicBoxScoreStarterHeaderValues[idx]
+			expectedHeader := basicBoxScoreStarterHeaders[idx]
 			if starterHeader != expectedHeader {
 				log.Fatalf("Starter header '%s' at position %d does not equal expected header '%s' @ %s\n", starterHeader, idx, expectedHeader, url)
 			}
@@ -339,7 +339,7 @@ func (boxScoreRunner *BasicBoxScoreRunner) GetSegmentBoxScoreStats(matchup inter
 			} else {
 				s.Find(boxScoreReserveHeaders).Each(func(idx int, s *goquery.Selection) {
 					reserveHeader = util.CleanTextDatum(s.Text())
-					expectedHeader := basicBoxScoreReservesHeaderValues[idx]
+					expectedHeader := basicBoxScoreReservesHeaders[idx]
 					if reserveHeader != expectedHeader {
 						log.Fatalf("Reserve header '%s' at position %d does not equal expected header '%s' @ %s\n", reserveHeader, idx, expectedHeader, url)
 					}

--- a/dataprovider/basketballreference/nba/basic_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/basic_box_score_stats.go
@@ -21,54 +21,54 @@ const (
 
 // basicBoxScoreStarterHeaderValues represents the headers in sequential order for the starter team members
 var basicBoxScoreStarterHeaderValues headerValues = headerValues{
-	"Starters": struct{}{},
-	"MP":       struct{}{},
-	"FG":       struct{}{},
-	"FGA":      struct{}{},
-	"FG%":      struct{}{},
-	"3P":       struct{}{},
-	"3PA":      struct{}{},
-	"3P%":      struct{}{},
-	"FT":       struct{}{},
-	"FTA":      struct{}{},
-	"FT%":      struct{}{},
-	"ORB":      struct{}{},
-	"DRB":      struct{}{},
-	"TRB":      struct{}{},
-	"AST":      struct{}{},
-	"STL":      struct{}{},
-	"BLK":      struct{}{},
-	"TOV":      struct{}{},
-	"PF":       struct{}{},
-	"PTS":      struct{}{},
-	"GmSc":     struct{}{},
-	"+/-":      struct{}{},
+	"Starters",
+	"MP",
+	"FG",
+	"FGA",
+	"FG%",
+	"3P",
+	"3PA",
+	"3P%",
+	"FT",
+	"FTA",
+	"FT%",
+	"ORB",
+	"DRB",
+	"TRB",
+	"AST",
+	"STL",
+	"BLK",
+	"TOV",
+	"PF",
+	"PTS",
+	"GmSc",
+	"+/-",
 }
 
 // basicBoxScoreReservesHeaderValues represents the headers in sequential order for the reserve team members
 var basicBoxScoreReservesHeaderValues headerValues = headerValues{
-	"Reserves": struct{}{},
-	"MP":       struct{}{},
-	"FG":       struct{}{},
-	"FGA":      struct{}{},
-	"FG%":      struct{}{},
-	"3P":       struct{}{},
-	"3PA":      struct{}{},
-	"3P%":      struct{}{},
-	"FT":       struct{}{},
-	"FTA":      struct{}{},
-	"FT%":      struct{}{},
-	"ORB":      struct{}{},
-	"DRB":      struct{}{},
-	"TRB":      struct{}{},
-	"AST":      struct{}{},
-	"STL":      struct{}{},
-	"BLK":      struct{}{},
-	"TOV":      struct{}{},
-	"PF":       struct{}{},
-	"PTS":      struct{}{},
-	"GmSc":     struct{}{},
-	"+/-":      struct{}{},
+	"Reserves",
+	"MP",
+	"FG",
+	"FGA",
+	"FG%",
+	"3P",
+	"3PA",
+	"3P%",
+	"FT",
+	"FTA",
+	"FT%",
+	"ORB",
+	"DRB",
+	"TRB",
+	"AST",
+	"STL",
+	"BLK",
+	"TOV",
+	"PF",
+	"PTS",
+	"GmSc",
+	"+/-",
 }
 
 // BasicBoxScoreOption defines a configuration option for basic box score runners
@@ -134,11 +134,11 @@ func (boxScoreRunner *BasicBoxScoreRunner) GetSegmentBoxScoreStats(matchup inter
 	doc.Find(basicBoxScoreSelector).Each(func(i int, s *goquery.Selection) {
 		var starterHeader string
 		var reserveHeader string
-		s.Find(boxScoreStarterHeaders).Each(func(_ int, s *goquery.Selection) {
+		s.Find(boxScoreStarterHeaders).Each(func(idx int, s *goquery.Selection) {
 			starterHeader = util.CleanTextDatum(s.Text())
-			_, ok := basicBoxScoreStarterHeaderValues[starterHeader]
-			if !ok {
-				log.Fatalf("%s is not a valid Starters Header @ %s\n", starterHeader, url)
+			expectedHeader := basicBoxScoreStarterHeaderValues[idx]
+			if starterHeader != expectedHeader {
+				log.Fatalf("Starter header '%s' at position %d does not equal expected header '%s' @ %s\n", starterHeader, idx, expectedHeader, url)
 			}
 		})
 
@@ -337,14 +337,12 @@ func (boxScoreRunner *BasicBoxScoreRunner) GetSegmentBoxScoreStats(matchup inter
 				}
 				basicNBABoxScoreStats = append(basicNBABoxScoreStats, boxScoreStats)
 			} else {
-				s.Find(boxScoreReserveHeaders).Each(func(_ int, s *goquery.Selection) {
-
+				s.Find(boxScoreReserveHeaders).Each(func(idx int, s *goquery.Selection) {
 					reserveHeader = util.CleanTextDatum(s.Text())
-					_, ok := basicBoxScoreReservesHeaderValues[reserveHeader]
-					if !ok {
-						log.Fatalf("%s is not a valid Reserves Header @ %s\n", reserveHeader, url)
+					expectedHeader := basicBoxScoreReservesHeaderValues[idx]
+					if reserveHeader != expectedHeader {
+						log.Fatalf("Reserve header '%s' at position %d does not equal expected header '%s' @ %s\n", reserveHeader, idx, expectedHeader, url)
 					}
-
 				})
 			}
 

--- a/dataprovider/basketballreference/nba/matchups.go
+++ b/dataprovider/basketballreference/nba/matchups.go
@@ -182,7 +182,7 @@ func (matchupRunner *MatchupRunner) GetMatchups(date string) []interface{} {
 		matchup.BoxScoreLink = basketballreference.URL + urlPath
 
 		// EventID
-		eventID, err := sportsreferenceutil.PlayerID(matchup.BoxScoreLink)
+		eventID, err := sportsreferenceutil.EventID(matchup.BoxScoreLink)
 		if err != nil {
 			log.Fatalln(err)
 		}

--- a/dataprovider/basketballreference/nba/matchups.go
+++ b/dataprovider/basketballreference/nba/matchups.go
@@ -3,7 +3,6 @@ package nba
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference"
 	"github.com/lightning-dabbler/sportscrape/dataprovider/basketballreference/nba/model"
@@ -183,8 +182,11 @@ func (matchupRunner *MatchupRunner) GetMatchups(date string) []interface{} {
 		matchup.BoxScoreLink = basketballreference.URL + urlPath
 
 		// EventID
-		splitLink := strings.Split(matchup.BoxScoreLink, "/")
-		matchup.EventID = strings.Split(splitLink[len(splitLink)-1], ".")[0]
+		eventID, err := sportsreferenceutil.PlayerID(matchup.BoxScoreLink)
+		if err != nil {
+			log.Fatalln(err)
+		}
+		matchup.EventID = eventID
 
 		// Quarter Headers check
 		var selector string

--- a/dataprovider/basketballreference/nba/model/matchup.go
+++ b/dataprovider/basketballreference/nba/model/matchup.go
@@ -8,7 +8,7 @@ import (
 type NBAMatchup struct {
 	// PullTimestamp is the fetch timestamp for when the request was made to the API
 	PullTimestamp time.Time `json:"pull_timestamp"`
-	// EventID is the parsed event id from the response payload of the matchup
+	// EventID is the parsed event id from the box score link of the matchup
 	EventID string `json:"event_id"`
 	// EventDate is the timestamp associated with a given event
 	EventDate time.Time `json:"event_date"`

--- a/dataprovider/basketballreference/nba/shared.go
+++ b/dataprovider/basketballreference/nba/shared.go
@@ -23,8 +23,6 @@ var networkHeaders network.Headers = network.Headers(map[string]interface{}{
 	"user-agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.53 Safari/537.36",
 })
 
-type headerValues []string
-
 const (
 	// https://www.basketball-reference.com/boxscores/{event_id}.html
 	waitReadyBoxScoreContentSelector = `#content`

--- a/dataprovider/basketballreference/nba/shared.go
+++ b/dataprovider/basketballreference/nba/shared.go
@@ -23,7 +23,7 @@ var networkHeaders network.Headers = network.Headers(map[string]interface{}{
 	"user-agent":                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.53 Safari/537.36",
 })
 
-type headerValues map[string]struct{}
+type headerValues []string
 
 const (
 	// https://www.basketball-reference.com/boxscores/{event_id}.html

--- a/dataprovider/basketballreference/nba/shared.go
+++ b/dataprovider/basketballreference/nba/shared.go
@@ -35,16 +35,6 @@ const (
 	boxScorePlayerLinkSelector       = boxScorePlayerSelector + " > a"
 )
 
-// extractPlayerID extracts PlayerID from PlayerLink
-func extractPlayerID(playerLink string) (string, error) {
-	playerLinkSplit := strings.Split(playerLink, "/")
-	result := strings.Split(playerLinkSplit[len(playerLinkSplit)-1], ".")[0]
-	if result == "" {
-		return "", fmt.Errorf("Error: Player ID is an empty string when parsing %s", playerLink)
-	}
-	return result, nil
-}
-
 func transformMinutesPlayed(minutesPlayed string) (float32, error) {
 	minutesPlayedSplit := strings.Split(minutesPlayed, ":")
 	minutes, err := util.TextToInt(minutesPlayedSplit[0])

--- a/dataprovider/basketballreference/nba/shared_test.go
+++ b/dataprovider/basketballreference/nba/shared_test.go
@@ -8,46 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestExtractPlayerID(t *testing.T) {
-	tests := []struct {
-		name        string
-		link        string
-		expectation string
-		isError     bool
-	}{
-		{
-			name:        "trae young player ID",
-			link:        "https://www.basketball-reference.com/players/y/youngtr01.html",
-			expectation: "youngtr01",
-		},
-		{
-			name:        "clint capela player ID",
-			link:        "https://www.basketball-reference.com/players/c/capelca01.html",
-			expectation: "capelca01",
-		},
-		{
-			name:        "cole anthony player ID",
-			link:        "https://www.basketball-reference.com/players/a/anthoco01.html",
-			expectation: "anthoco01",
-		},
-		{
-			name:    "Error empty string",
-			link:    "",
-			isError: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			actual, err := extractPlayerID(tt.link)
-			if tt.isError {
-				assert.Error(t, err)
-			} else {
-				assert.Equal(t, tt.expectation, actual, "Equal player id")
-			}
-		})
-	}
-}
-
 func TestTransformMinutesPlayed(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/util/sportsreference/util.go
+++ b/util/sportsreference/util.go
@@ -88,6 +88,8 @@ type loserValues map[string]struct{}
 // LoserValueExists is a helper to determine losers and winners in a matchup
 var LoserValueExists loserValues = loserValues{"loser": struct{}{}, "winner": struct{}{}}
 
+type Headers []string
+
 // ReturnUnemptyField validates that the extracted field from a selector is not an empty string
 //
 // Paramater:

--- a/util/sportsreference/util.go
+++ b/util/sportsreference/util.go
@@ -2,6 +2,7 @@ package sportsreferenceutil
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -11,7 +12,11 @@ const (
 )
 
 // DateStrToTime takes in a date string in the form 2024-01-25
-// Returns a timestamp and error
+//
+// Parameter:
+//   - date: the date string to parse
+//
+// Returns a time.Time{} and nilable error
 func DateStrToTime(date string) (time.Time, error) {
 	dateParse, err := time.Parse(dateLayout, date)
 	if err != nil {
@@ -21,7 +26,11 @@ func DateStrToTime(date string) (time.Time, error) {
 }
 
 // EventDate takes in a date string in the form 2024-01-25
-// Returns a timezone (America/New_York) aware timestamp error
+//
+// Parameter:
+//   - date: The date associated with the event
+//
+// Returns the event date as time.Time{} with timezone (America/New_York) awareness and nilable error
 func EventDate(date string) (time.Time, error) {
 	loc, err := time.LoadLocation("America/New_York")
 	if err != nil {
@@ -35,13 +44,58 @@ func EventDate(date string) (time.Time, error) {
 	return dateParse, nil
 }
 
+// extractID extracts an arbitrary id from a sportsreference related link
+//
+// Parameter:
+//   - link: the url
+//
+// Returns the id parsed from the url
+func extractID(link string) string {
+	linkSplit := strings.Split(link, "/")
+	return strings.Split(linkSplit[len(linkSplit)-1], ".")[0]
+}
+
+// EventID extracts the event id from a boxscore link
+//
+// Parameter:
+//   - boxscoreLink: the boxscore link
+//
+// Returns the event id as a string and nilable error
+func EventID(boxscoreLink string) (string, error) {
+	id := extractID(boxscoreLink)
+	if id == "" {
+		return "", fmt.Errorf("Error: Event ID is an empty string when parsing %s", id)
+	}
+	return id, nil
+}
+
+// PlayerID extracts the player id from a player link
+//
+// Parameter:
+//   - playerLink: the player link
+//
+// Returns the player id as a string and nilable error
+func PlayerID(playerLink string) (string, error) {
+	id := extractID(playerLink)
+	if id == "" {
+		return "", fmt.Errorf("Error: Player ID is an empty string when parsing %s", id)
+	}
+	return id, nil
+}
+
 type loserValues map[string]struct{}
 
 // LoserValueExists is a helper to determine losers and winners in a matchup
 var LoserValueExists loserValues = loserValues{"loser": struct{}{}, "winner": struct{}{}}
 
 // ReturnUnemptyField validates that the extracted field from a selector is not an empty string
-// Returns the string if not empty else raises a logs an issue and fails the process
+//
+// Paramater:
+//   - str: the value to validate
+//   - location: selector
+//   - field: the model field
+//
+// Returns the string if not empty and nilable error
 func ReturnUnemptyField(str string, location string, field string) (string, error) {
 	if str == "" {
 		return "", fmt.Errorf("No value @ %s for %s", location, field)

--- a/util/sportsreference/util_test.go
+++ b/util/sportsreference/util_test.go
@@ -160,3 +160,118 @@ func TestReturnUnemptyField(t *testing.T) {
 		})
 	}
 }
+
+func TestExtractID(t *testing.T) {
+	tests := []struct {
+		name        string
+		link        string
+		expectation string
+	}{
+		{
+			name:        "trae young player ID",
+			link:        "https://www.basketball-reference.com/players/y/youngtr01.html",
+			expectation: "youngtr01",
+		},
+		{
+			name:        "clint capela player ID",
+			link:        "https://www.basketball-reference.com/players/c/capelca01.html",
+			expectation: "capelca01",
+		},
+		{
+			name:        "cole anthony player ID",
+			link:        "https://www.basketball-reference.com/players/a/anthoco01.html",
+			expectation: "anthoco01",
+		},
+		{
+			name:        "empty string",
+			link:        "",
+			expectation: "",
+		},
+		{
+			name:        "baseball event id",
+			link:        "https://www.baseball-reference.com/boxes/MIL/MIL202409020.shtml",
+			expectation: "MIL202409020",
+		},
+		{
+			name:        "baseball player id",
+			link:        "https://www.baseball-reference.com/players/w/winnma01.shtml",
+			expectation: "winnma01",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := extractID(tt.link)
+			assert.Equal(t, tt.expectation, actual, "Equal id")
+		})
+	}
+}
+
+func TestPlayerID(t *testing.T) {
+	tests := []struct {
+		name        string
+		link        string
+		expectation string
+		isError     bool
+	}{
+		{
+			name:        "trae young player ID",
+			link:        "https://www.basketball-reference.com/players/y/youngtr01.html",
+			expectation: "youngtr01",
+		},
+		{
+			name:        "masyn winn player ID",
+			link:        "https://www.baseball-reference.com/players/w/winnma01.shtml",
+			expectation: "winnma01",
+		},
+		{
+			name:    "empty string",
+			link:    "",
+			isError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := PlayerID(tt.link)
+			if tt.isError {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tt.expectation, actual, "Equal player id")
+			}
+		})
+	}
+}
+
+func TestEventID(t *testing.T) {
+	tests := []struct {
+		name        string
+		link        string
+		expectation string
+		isError     bool
+	}{
+		{
+			name:    "empty string",
+			link:    "",
+			isError: true,
+		},
+		{
+			name:        "baseball event id",
+			link:        "https://www.baseball-reference.com/boxes/MIL/MIL202409020.shtml",
+			expectation: "MIL202409020",
+		},
+		{
+			name:        "baseball event id",
+			link:        "https://www.basketball-reference.com/boxscores/202503060ORL.html",
+			expectation: "202503060ORL",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := EventID(tt.link)
+			if tt.isError {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tt.expectation, actual, "Equal event id")
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Context
### Added
- Added EventID to sportsreference util and updated `MatchupRunner.GetMatchups(...)` to use it.
- Created `MLBMatchup` model and `MatchupRunner` to scrape MLB matchups from https://baseball-reference.com
- Created `MLBBattingBoxScoreStats` and `BattingBoxScoreRunner` to scrape MLB batting box score data from https://baseball-reference.com
- Created `MLBPitchingBoxScoreStats` model and `PitchingBoxScoreRunner` to scrape MLB pitching box score data from https://baseball-reference.com
### Changed
- Moved local extractPlayerID to sportsreference util and renamed it PlayerID
- Changed `headerValues` type from map to slice of string
- renamed `headerValues` to `Headers`
- Moved `Headers` to sportsreferenceutil package
- Only run tests when go package related files have been modified