### PR TITLE
NBA basketball-reference: Enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Created `Round` util function
+- Support for scraping all periods to NBA `BasicBoxScoreRunner`
+### Changed
+- 2 decimal place precision for `transformMinutesPlayed`
+- Documentation updates
 
 ## [0.1.0] - 2025-04-01
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ func main() {
 
 ## Data providers
 
-| Source                           | League | Feed                  | Requires Chromium|
-|----------------------------------|--------|-----------------------|:----------------:|
-| https://basketball-reference.com | NBA    | Matchup               |[x]|
-| https://basketball-reference.com | NBA    | Basic box score stats |[x]|
-| https://basketball-reference.com | NBA    | Advanced box score stats|[x]|
-| https://baseball-reference.com   | MLB    | Matchup                |[x]|
-| https://baseball-reference.com   | MLB    | Batting box score stats|[x]|
-| https://baseball-reference.com   | MLB    | Pitching box score stats|[x]|
+| Source                           | League | Feed                  | Periods Available       | Requires Chromium|
+|----------------------------------|--------|------------------------|:----------------------:|:----------------:|
+| https://basketball-reference.com | NBA    | Matchup                | Full                   |[x]|
+| https://basketball-reference.com | NBA    | Basic box score stats  | H1, H2, Q1, Q2, Q3, Q4, Full |[x]|
+| https://basketball-reference.com | NBA    | Advanced box score stats| Full                  |[x]|
+| https://baseball-reference.com   | MLB    | Matchup                | Full                   |[x]|
+| https://baseball-reference.com   | MLB    | Batting box score stats| Full                   |[x]|
+| https://baseball-reference.com   | MLB    | Pitching box score stats| Full                  |[x]|
 
 ## Development
 ### Prerequisites

--- a/dataprovider/basketballreference/nba/basic_box_score_stats_test.go
+++ b/dataprovider/basketballreference/nba/basic_box_score_stats_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetBasicBoxScoreStats(t *testing.T) {
+func TestGetFullBasicBoxScoreStats(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}
@@ -50,7 +50,7 @@ func TestGetBasicBoxScoreStats(t *testing.T) {
 			}
 			// Sample player stats from away team (LaMelo Ball)
 			if stats.Player == "LaMelo Ball" {
-				assert.Equal(t, true, stats.Starter, "LaMelo was a starter")
+				assert.Equal(t, true, stats.Starter, "LaMelo is a starter")
 				assert.Equal(t, "ballla01", stats.PlayerID, "LaMelo's player ID")
 				assert.Equal(t, "LA Lakers", stats.Opponent, "LaMelo's opposing team")
 				assert.Equal(t, "https://www.basketball-reference.com/players/b/ballla01.html", stats.PlayerLink, "LaMelo's player link")
@@ -83,4 +83,202 @@ func TestGetBasicBoxScoreStats(t *testing.T) {
 	assert.Equal(t, expectedNumHomePlayers, numHomePlayers, "Assert number of home players on LA Lakers")
 	assert.Equal(t, expectedAwayDNP, numAwayDNP, "Assert number of away players on Charlotte that did not play")
 	assert.Equal(t, expectedHomeDNP, numHomeDNP, "Assert number of home players on LA Lakers that did not play")
+}
+
+func TestGetH1BasicBoxScoreStats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	date := "2025-02-19"
+	matchupRunner := NewMatchupRunner(
+		WithMatchupTimeout(2 * time.Minute),
+	)
+	matchups := matchupRunner.GetMatchups(date)
+	boxScoreRunner := NewBasicBoxScoreRunner(
+		WithBasicBoxScoreTimeout(4*time.Minute),
+		WithBasicBoxScoreConcurrency(1),
+		WithBasicBoxScorePeriod(H1),
+	)
+	basicBoxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
+
+	playerToTest := map[string]bool{
+		"LaMelo Ball":  false,
+		"Luka Dončić":  false,
+		"Gabe Vincent": false,
+	}
+
+	for _, s := range basicBoxScoreStats {
+		stats := s.(model.NBABasicBoxScoreStats)
+		if stats.Player == "LaMelo Ball" {
+			playerToTest["LaMelo Ball"] = true
+			assert.Equal(t, true, stats.Starter, "LaMelo is a starter")
+			assert.Equal(t, "ballla01", stats.PlayerID, "LaMelo's player ID")
+			assert.Equal(t, "LA Lakers", stats.Opponent, "LaMelo's opposing team")
+			assert.Equal(t, "https://www.basketball-reference.com/players/b/ballla01.html", stats.PlayerLink, "LaMelo's player link")
+			assert.Equal(t, float32(14.78), stats.MinutesPlayed, "LaMelo minutes played")
+			assert.Equal(t, 4, stats.FieldGoalsMade, "LaMelo field goals made")
+			assert.Equal(t, 9, stats.FieldGoalAttempts, "LaMelo field goal attempts")
+			assert.Equal(t, float32(0.444), stats.FieldGoalPercentage, "LaMelo field goal percentage")
+			assert.Equal(t, 1, stats.ThreePointsMade, "LaMelo three points made")
+			assert.Equal(t, 4, stats.ThreePointAttempts, "LaMelo three point attempts")
+			assert.Equal(t, float32(0.250), stats.ThreePointPercentage, "LaMelo three point percentage")
+			assert.Equal(t, 0, stats.FreeThrowsMade, "LaMelo free thows made")
+			assert.Equal(t, 0, stats.FreeThrowAttempts, "LaMelo free throw attempts")
+			assert.Equal(t, float32(0), stats.FreeThrowPercentage, "LaMelo free throw percentage")
+			assert.Equal(t, 0, stats.OffensiveRebounds, "LaMelo offensive rebounds")
+			assert.Equal(t, 0, stats.DefensiveRebounds, "LaMelo defensive rebounds")
+			assert.Equal(t, 0, stats.TotalRebounds, "LaMelo total rebounds")
+			assert.Equal(t, 3, stats.Assists, "LaMelo assists")
+			assert.Equal(t, 0, stats.Steals, "LaMelo steals")
+			assert.Equal(t, 0, stats.Blocks, "LaMelo blocks")
+			assert.Equal(t, 2, stats.Turnovers, "LaMelo turnovers")
+			assert.Equal(t, 1, stats.PersonalFouls, "LaMelo personal fouls")
+			assert.Equal(t, 9, stats.Points, "LaMelo points")
+			assert.Equal(t, float32(4.0), stats.GameScore, "LaMelo game score")
+			assert.Equal(t, -3, stats.PlusMinus, "LaMelo plus minus")
+		} else if stats.Player == "Luka Dončić" {
+			playerToTest["Luka Dončić"] = true
+			assert.Equal(t, true, stats.Starter, "Luka is a starter")
+			assert.Equal(t, "doncilu01", stats.PlayerID, "Luka's player ID")
+			assert.Equal(t, "Charlotte", stats.Opponent, "Luka's opposing team")
+			assert.Equal(t, "https://www.basketball-reference.com/players/d/doncilu01.html", stats.PlayerLink, "Luka's player link")
+			assert.Equal(t, float32(15.55), stats.MinutesPlayed, "Luka minutes played")
+			assert.Equal(t, 2, stats.FieldGoalsMade, "Luka field goals made")
+			assert.Equal(t, 9, stats.FieldGoalAttempts, "Luka field goal attempts")
+			assert.Equal(t, float32(0.222), stats.FieldGoalPercentage, "Luka field goal percentage")
+			assert.Equal(t, 0, stats.ThreePointsMade, "Luka three points made")
+			assert.Equal(t, 5, stats.ThreePointAttempts, "Luka three point attempts")
+			assert.Equal(t, float32(0), stats.ThreePointPercentage, "Luka three point percentage")
+			assert.Equal(t, 0, stats.FreeThrowsMade, "Luka free thows made")
+			assert.Equal(t, 0, stats.FreeThrowAttempts, "Luka free throw attempts")
+			assert.Equal(t, float32(0), stats.FreeThrowPercentage, "Luka free throw percentage")
+			assert.Equal(t, 0, stats.OffensiveRebounds, "Luka offensive rebounds")
+			assert.Equal(t, 7, stats.DefensiveRebounds, "Luka defensive rebounds")
+			assert.Equal(t, 7, stats.TotalRebounds, "Luka total rebounds")
+			assert.Equal(t, 5, stats.Assists, "Luka assists")
+			assert.Equal(t, 0, stats.Steals, "Luka steals")
+			assert.Equal(t, 0, stats.Blocks, "Luka blocks")
+			assert.Equal(t, 5, stats.Turnovers, "Luka turnovers")
+			assert.Equal(t, 1, stats.PersonalFouls, "Luka personal fouls")
+			assert.Equal(t, 4, stats.Points, "Luka points")
+			assert.Equal(t, float32(-1.3), stats.GameScore, "Luka game score")
+			assert.Equal(t, 10, stats.PlusMinus, "Luka plus minus")
+
+		} else if stats.Player == "Gabe Vincent" {
+			playerToTest["Gabe Vincent"] = true
+			assert.Equal(t, false, stats.Starter, "Gabe is a reserves player")
+			assert.Equal(t, "vincega01", stats.PlayerID, "Gabe's player ID")
+			assert.Equal(t, "Charlotte", stats.Opponent, "Gabe's opposing team")
+			assert.Equal(t, "https://www.basketball-reference.com/players/v/vincega01.html", stats.PlayerLink, "Gabe's player link")
+			assert.Equal(t, float32(10.65), stats.MinutesPlayed, "Gabe minutes played")
+			assert.Equal(t, 2, stats.FieldGoalsMade, "Gabe field goals made")
+			assert.Equal(t, 5, stats.FieldGoalAttempts, "Gabe field goal attempts")
+			assert.Equal(t, float32(0.4), stats.FieldGoalPercentage, "Gabe field goal percentage")
+			assert.Equal(t, 2, stats.ThreePointsMade, "Gabe three points made")
+			assert.Equal(t, 5, stats.ThreePointAttempts, "Gabe three point attempts")
+			assert.Equal(t, float32(0.4), stats.ThreePointPercentage, "Gabe three point percentage")
+			assert.Equal(t, 0, stats.FreeThrowsMade, "Gabe free thows made")
+			assert.Equal(t, 0, stats.FreeThrowAttempts, "Gabe free throw attempts")
+			assert.Equal(t, float32(0), stats.FreeThrowPercentage, "Gabe free throw percentage")
+			assert.Equal(t, 1, stats.OffensiveRebounds, "Gabe offensive rebounds")
+			assert.Equal(t, 1, stats.DefensiveRebounds, "Gabe defensive rebounds")
+			assert.Equal(t, 2, stats.TotalRebounds, "Gabe total rebounds")
+			assert.Equal(t, 1, stats.Assists, "Gabe assists")
+			assert.Equal(t, 0, stats.Steals, "Gabe steals")
+			assert.Equal(t, 0, stats.Blocks, "Gabe blocks")
+			assert.Equal(t, 1, stats.Turnovers, "Gabe turnovers")
+			assert.Equal(t, 2, stats.PersonalFouls, "Gabe personal fouls")
+			assert.Equal(t, 6, stats.Points, "Gabe points")
+			assert.Equal(t, float32(3.2), stats.GameScore, "Gabe game score")
+			assert.Equal(t, 10, stats.PlusMinus, "Gabe plus minus")
+
+		}
+	}
+	assert.True(t, playerToTest["LaMelo Ball"], "LaMelo Ball's stats were collected")
+	assert.True(t, playerToTest["Luka Dončić"], "Luka Dončić's stats were collected")
+	assert.True(t, playerToTest["Gabe Vincent"], "Gabe Vincent's stats were collected")
+}
+
+func TestGetQ3BasicBoxScoreStats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	date := "2025-02-19"
+	matchupRunner := NewMatchupRunner(
+		WithMatchupTimeout(2 * time.Minute),
+	)
+	matchups := matchupRunner.GetMatchups(date)
+	boxScoreRunner := NewBasicBoxScoreRunner(
+		WithBasicBoxScoreTimeout(4*time.Minute),
+		WithBasicBoxScoreConcurrency(1),
+		WithBasicBoxScorePeriod(Q3),
+	)
+	basicBoxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
+	playerToTest := map[string]bool{
+		"Tidjane Salaün": false,
+		"Rui Hachimura":  false,
+	}
+
+	for _, s := range basicBoxScoreStats {
+		stats := s.(model.NBABasicBoxScoreStats)
+		if stats.Player == "Tidjane Salaün" {
+			playerToTest["Tidjane Salaün"] = true
+			assert.Equal(t, false, stats.Starter, "Tidjane is a reserves player")
+			assert.Equal(t, "salauti01", stats.PlayerID, "Tidjane's player ID")
+			assert.Equal(t, "LA Lakers", stats.Opponent, "Tidjane's opposing team")
+			assert.Equal(t, "https://www.basketball-reference.com/players/s/salauti01.html", stats.PlayerLink, "Tidjane's player link")
+			assert.Equal(t, float32(0), stats.MinutesPlayed, "Tidjane minutes played")
+			assert.Equal(t, 0, stats.FieldGoalsMade, "Tidjane field goals made")
+			assert.Equal(t, 0, stats.FieldGoalAttempts, "Tidjane field goal attempts")
+			assert.Equal(t, float32(0), stats.FieldGoalPercentage, "Tidjane field goal percentage")
+			assert.Equal(t, 0, stats.ThreePointsMade, "Tidjane three points made")
+			assert.Equal(t, 0, stats.ThreePointAttempts, "Tidjane three point attempts")
+			assert.Equal(t, float32(0), stats.ThreePointPercentage, "Tidjane three point percentage")
+			assert.Equal(t, 0, stats.FreeThrowsMade, "Tidjane free thows made")
+			assert.Equal(t, 0, stats.FreeThrowAttempts, "Tidjane free throw attempts")
+			assert.Equal(t, float32(0), stats.FreeThrowPercentage, "Tidjane free throw percentage")
+			assert.Equal(t, 0, stats.OffensiveRebounds, "Tidjane offensive rebounds")
+			assert.Equal(t, 0, stats.DefensiveRebounds, "Tidjane defensive rebounds")
+			assert.Equal(t, 0, stats.TotalRebounds, "Tidjane total rebounds")
+			assert.Equal(t, 0, stats.Assists, "Tidjane assists")
+			assert.Equal(t, 0, stats.Steals, "Tidjane steals")
+			assert.Equal(t, 0, stats.Blocks, "Tidjane blocks")
+			assert.Equal(t, 0, stats.Turnovers, "Tidjane turnovers")
+			assert.Equal(t, 0, stats.PersonalFouls, "Tidjane personal fouls")
+			assert.Equal(t, 0, stats.Points, "Tidjane points")
+			assert.Equal(t, float32(0), stats.GameScore, "Tidjane game score")
+			assert.Equal(t, 0, stats.PlusMinus, "Tidjane plus minus")
+		} else if stats.Player == "Rui Hachimura" {
+			playerToTest["Rui Hachimura"] = true
+			assert.Equal(t, true, stats.Starter, "Rui is a starter")
+			assert.Equal(t, "hachiru01", stats.PlayerID, "Rui's player ID")
+			assert.Equal(t, "Charlotte", stats.Opponent, "Rui's opposing team")
+			assert.Equal(t, "https://www.basketball-reference.com/players/h/hachiru01.html", stats.PlayerLink, "Rui's player link")
+			assert.Equal(t, float32(10.27), stats.MinutesPlayed, "Rui minutes played")
+			assert.Equal(t, 2, stats.FieldGoalsMade, "Rui field goals made")
+			assert.Equal(t, 5, stats.FieldGoalAttempts, "Rui field goal attempts")
+			assert.Equal(t, float32(.4), stats.FieldGoalPercentage, "Rui field goal percentage")
+			assert.Equal(t, 0, stats.ThreePointsMade, "Rui three points made")
+			assert.Equal(t, 2, stats.ThreePointAttempts, "Rui three point attempts")
+			assert.Equal(t, float32(0), stats.ThreePointPercentage, "Rui three point percentage")
+			assert.Equal(t, 0, stats.FreeThrowsMade, "Rui free thows made")
+			assert.Equal(t, 0, stats.FreeThrowAttempts, "Rui free throw attempts")
+			assert.Equal(t, float32(0), stats.FreeThrowPercentage, "Rui free throw percentage")
+			assert.Equal(t, 1, stats.OffensiveRebounds, "Rui offensive rebounds")
+			assert.Equal(t, 0, stats.DefensiveRebounds, "Rui defensive rebounds")
+			assert.Equal(t, 1, stats.TotalRebounds, "Rui total rebounds")
+			assert.Equal(t, 0, stats.Assists, "Rui assists")
+			assert.Equal(t, 0, stats.Steals, "Rui steals")
+			assert.Equal(t, 0, stats.Blocks, "Rui blocks")
+			assert.Equal(t, 0, stats.Turnovers, "Rui turnovers")
+			assert.Equal(t, 0, stats.PersonalFouls, "Rui personal fouls")
+			assert.Equal(t, 4, stats.Points, "Rui points")
+			assert.Equal(t, float32(2), stats.GameScore, "Rui game score")
+			assert.Equal(t, -5, stats.PlusMinus, "Rui plus minus")
+
+		}
+
+	}
+	assert.True(t, playerToTest["Tidjane Salaün"], "Tidjane Salaün's stats were collected")
+	assert.True(t, playerToTest["Rui Hachimura"], "Rui Hachimura's stats were collected")
 }

--- a/dataprovider/basketballreference/nba/example_test.go
+++ b/dataprovider/basketballreference/nba/example_test.go
@@ -22,8 +22,8 @@ func ExampleMatchupRunner() {
 	}
 }
 
-// Example for nba.BasicBoxScoreRunner
-func ExampleBasicBoxScoreRunner() {
+// Example for nba.BasicBoxScoreRunner Full basic box score stats
+func ExampleBasicBoxScoreRunner_full() {
 	date := "2025-02-19"
 	// Instantiate MatchupRunner
 	matchupRunner := nba.NewMatchupRunner(
@@ -35,6 +35,52 @@ func ExampleBasicBoxScoreRunner() {
 	boxScoreRunner := nba.NewBasicBoxScoreRunner(
 		nba.WithBasicBoxScoreTimeout(4*time.Minute),
 		nba.WithBasicBoxScoreConcurrency(1),
+	)
+	// Retrieve NBA basic box score stats associated with matchups
+	basicBoxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
+
+	for _, stats := range basicBoxScoreStats {
+		fmt.Printf("%#v\n", stats.(model.NBABasicBoxScoreStats))
+	}
+}
+
+// Example for nba.BasicBoxScoreRunner Q2 basic box score stats
+func ExampleBasicBoxScoreRunner_q2() {
+	date := "2025-02-19"
+	// Instantiate MatchupRunner
+	matchupRunner := nba.NewMatchupRunner(
+		nba.WithMatchupTimeout(2 * time.Minute),
+	)
+	// Retrieve NBA matchups associated with date
+	matchups := matchupRunner.GetMatchups(date)
+	// Instantiate BasicBoxScoreRunner
+	boxScoreRunner := nba.NewBasicBoxScoreRunner(
+		nba.WithBasicBoxScoreTimeout(4*time.Minute),
+		nba.WithBasicBoxScoreConcurrency(1),
+		nba.WithBasicBoxScorePeriod(nba.Q2),
+	)
+	// Retrieve NBA basic box score stats associated with matchups
+	basicBoxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)
+
+	for _, stats := range basicBoxScoreStats {
+		fmt.Printf("%#v\n", stats.(model.NBABasicBoxScoreStats))
+	}
+}
+
+// Example for nba.BasicBoxScoreRunner H2 basic box score stats
+func ExampleBasicBoxScoreRunner_h2() {
+	date := "2025-02-19"
+	// Instantiate MatchupRunner
+	matchupRunner := nba.NewMatchupRunner(
+		nba.WithMatchupTimeout(2 * time.Minute),
+	)
+	// Retrieve NBA matchups associated with date
+	matchups := matchupRunner.GetMatchups(date)
+	// Instantiate BasicBoxScoreRunner
+	boxScoreRunner := nba.NewBasicBoxScoreRunner(
+		nba.WithBasicBoxScoreTimeout(4*time.Minute),
+		nba.WithBasicBoxScoreConcurrency(1),
+		nba.WithBasicBoxScorePeriod(nba.H2),
 	)
 	// Retrieve NBA basic box score stats associated with matchups
 	basicBoxScoreStats := boxScoreRunner.GetBoxScoresStats(matchups...)

--- a/dataprovider/basketballreference/nba/shared.go
+++ b/dataprovider/basketballreference/nba/shared.go
@@ -45,6 +45,6 @@ func transformMinutesPlayed(minutesPlayed string) (float32, error) {
 		return 0, fmt.Errorf("Could not convert seconds %s to integer: %w", minutesPlayedSplit[1], err)
 	}
 
-	totalMinutes := float32(minutes) + (float32(seconds) / float32(60))
+	totalMinutes := float32(minutes) + float32(util.Round((float64(seconds)/float64(60)), 2))
 	return totalMinutes, nil
 }

--- a/util/math.go
+++ b/util/math.go
@@ -1,0 +1,15 @@
+package util
+
+import "math"
+
+// Round
+//
+// Parameter:
+//   - val: The number to round
+//   - x: Decimal places
+//
+// Returns a rounded float64 number
+func Round(val float64, x int) float64 {
+	factor := math.Pow(10, float64(x))
+	return math.Round(val*factor) / factor
+}

--- a/util/math_test.go
+++ b/util/math_test.go
@@ -1,0 +1,55 @@
+//go:build unit
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRound(t *testing.T) {
+	tests := []struct {
+		name     string
+		num      float64
+		places   int
+		expected float64
+	}{
+		{
+			name:     "3 decimal places",
+			num:      float64(4) / float64(3),
+			places:   3,
+			expected: float64(1.333),
+		},
+		{
+			name:     "0 decimal places",
+			num:      float64(75.4),
+			places:   0,
+			expected: float64(75),
+		},
+		{
+			name:     "0 decimal places pt 2",
+			num:      float64(30.5),
+			places:   0,
+			expected: float64(31),
+		},
+		{
+			name:     "2 decimal places",
+			num:      float64(30.493),
+			places:   2,
+			expected: float64(30.49),
+		},
+		{
+			name:     "2 decimal places pt 2",
+			num:      float64(2.265),
+			places:   2,
+			expected: float64(2.27),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, Round(tt.num, tt.places))
+		})
+	}
+}


### PR DESCRIPTION
## Context
- Added functionality to `BasicBoxScoreRunner` to scrape all NBA periods for basic box score stats (Full, Q1-Q4, H1, and H2)
- Added `Round` function
- Updated decimal place precision to 2 for minutes played
- Added more test cases