### PR TITLE
Parquet data model patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- added `convertedtype=UTF8` to all parquet string field tags
 
 ## [0.7.0] - 2025-04-17
 ### Added

--- a/dataprovider/baseballreference/mlb/model/batting_box_score_stats.go
+++ b/dataprovider/baseballreference/mlb/model/batting_box_score_stats.go
@@ -11,23 +11,23 @@ type MLBBattingBoxScoreStats struct {
 	// PullTimestampParquet is the fetch timestamp (in milliseconds)
 	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
 	// EventID is the parsed event id from the box score link of the matchup
-	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY"`
+	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// EventDate is the timestamp associated with a given event
 	EventDate time.Time `json:"event_date"`
 	// EventDateParquet is the timestamp associated with a given event (in days)
 	EventDateParquet int32 `json:"-" parquet:"name=event_date, type=INT32, convertedtype=DATE, logicaltype=DATE"`
 	// Team is the player's team name e.g. Atlanta Braves
-	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY"`
+	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Opponent is the opposing team name
-	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY"`
+	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayerID is the player's id
-	PlayerID string `json:"player_id" parquet:"name=player_id, type=BYTE_ARRAY"`
+	PlayerID string `json:"player_id" parquet:"name=player_id, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Player is the player's name
-	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY"`
+	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayerLink is the link to the player's baseball-reference profile
-	PlayerLink string `json:"player_link" parquet:"name=player_link, type=BYTE_ARRAY"`
+	PlayerLink string `json:"player_link" parquet:"name=player_link, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Position is the player's position
-	Position string `json:"position" parquet:"name=position, type=BYTE_ARRAY"`
+	Position string `json:"position" parquet:"name=position, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// AtBat (AB) - https://www.mlb.com/glossary/standard-stats/at-bat
 	AtBat int32 `json:"at_bat" parquet:"name=at_bat, type=INT32"`
 	// Runs (R) - https://www.mlb.com/glossary/standard-stats/run

--- a/dataprovider/baseballreference/mlb/model/matchup.go
+++ b/dataprovider/baseballreference/mlb/model/matchup.go
@@ -9,27 +9,27 @@ type MLBMatchup struct {
 	// PullTimestampParquet is the fetch timestamp (in milliseconds)
 	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
 	// EventID is the parsed event id from the box score link of the matchup
-	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY"`
+	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// EventDate is the timestamp associated with a given event
 	EventDate time.Time `json:"event_date"`
 	// EventDateParquet is the timestamp associated with a given event (in days)
 	EventDateParquet int32 `json:"-" parquet:"name=event_date, type=INT32, convertedtype=DATE, logicaltype=DATE"`
 	// AwayTeam is the away team's name
-	AwayTeam string `json:"away_team" parquet:"name=away_team, type=BYTE_ARRAY"`
+	AwayTeam string `json:"away_team" parquet:"name=away_team, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// HomeTeam is the home team's name
-	HomeTeam string `json:"home_team" parquet:"name=home_team, type=BYTE_ARRAY"`
+	HomeTeam string `json:"home_team" parquet:"name=home_team, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// HomeScore is the home team's final score
 	HomeScore int32 `json:"home_score" parquet:"name=home_score, type=INT32"`
 	// AwayScore is the away team's final score
 	AwayScore int32 `json:"away_score" parquet:"name=away_score, type=INT32"`
 	// BoxScoreLink is the link to box score for related to the event
-	BoxScoreLink string `json:"box_score_link" parquet:"name=box_score_link, type=BYTE_ARRAY"`
+	BoxScoreLink string `json:"box_score_link" parquet:"name=box_score_link, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// HomeTeamLink is the link to the home team's baseball-reference profile page
-	HomeTeamLink string `json:"home_team_link" parquet:"name=home_team_link, type=BYTE_ARRAY"`
+	HomeTeamLink string `json:"home_team_link" parquet:"name=home_team_link, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// AwayTeamLink is the link to the away team's baseball-reference profile page
-	AwayTeamLink string `json:"away_team_link" parquet:"name=away_team_link, type=BYTE_ARRAY"`
+	AwayTeamLink string `json:"away_team_link" parquet:"name=away_team_link, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Loser is the losing team's name
-	Loser string `json:"loser" parquet:"name=loser, type=BYTE_ARRAY"`
+	Loser string `json:"loser" parquet:"name=loser, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayoffMatch is whether or not the matchup was a playoff game
 	PlayoffMatch bool `json:"playoff_match" parquet:"name=playoff_match, type=BOOLEAN"`
 }

--- a/dataprovider/baseballreference/mlb/model/pitching_box_score_stats.go
+++ b/dataprovider/baseballreference/mlb/model/pitching_box_score_stats.go
@@ -11,21 +11,21 @@ type MLBPitchingBoxScoreStats struct {
 	// PullTimestampParquet is the fetch timestamp (in milliseconds)
 	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
 	// EventID is the parsed event id from the box score link of the matchup
-	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY"`
+	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// EventDate is the timestamp associated with a given event
 	EventDate time.Time `json:"event_date"`
 	// EventDateParquet is the timestamp associated with a given event (in days)
 	EventDateParquet int32 `json:"-" parquet:"name=event_date, type=INT32, convertedtype=DATE, logicaltype=DATE"`
 	// Team is the player's team name
-	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY"`
+	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Opponent is the opposing team name
-	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY"`
+	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayerID is the player's id extracted from the player's baseball-reference profile url
-	PlayerID string `json:"player_id" parquet:"name=player_id, type=BYTE_ARRAY"`
+	PlayerID string `json:"player_id" parquet:"name=player_id, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Player is the player's name
-	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY"`
+	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayerLink is the link to the player's baseball-reference profile
-	PlayerLink string `json:"player_link" parquet:"name=player_link, type=BYTE_ARRAY"`
+	PlayerLink string `json:"player_link" parquet:"name=player_link, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PitchingOrder - The sequence of pitchers who played during the event per team (starting from 1)
 	PitchingOrder int32 `json:"pitching_order" parquet:"name=pitching_order, type=INT32"`
 	// InningsPitched (IP) - https://www.mlb.com/glossary/standard-stats/innings-pitched

--- a/dataprovider/basketballreference/nba/model/adv_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/model/adv_box_score_stats.go
@@ -9,21 +9,21 @@ type NBAAdvBoxScoreStats struct {
 	// PullTimestampParquet is the fetch timestamp (in milliseconds)
 	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
 	// EventID is the parsed event id from the box score link of the matchup
-	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY"`
+	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// EventDate is the timestamp associated with a given event
 	EventDate time.Time `json:"event_date"`
 	// EventDateParquet is the timestamp associated with a given event (in days)
 	EventDateParquet int32 `json:"-" parquet:"name=event_date, type=INT32, convertedtype=DATE, logicaltype=DATE"`
 	// Team is the player's team name
-	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY"`
+	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Opponent is the opposing team name
-	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY"`
+	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayerID is the player's id extracted from the player's basketball-reference profile url
-	PlayerID string `json:"player_id" parquet:"name=player_id, type=BYTE_ARRAY"`
+	PlayerID string `json:"player_id" parquet:"name=player_id, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Player is the player's name
-	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY"`
+	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayerLink is the link to the player's basketball-reference profile
-	PlayerLink string `json:"player_link" parquet:"name=player_link, type=BYTE_ARRAY"`
+	PlayerLink string `json:"player_link" parquet:"name=player_link, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Starter is whether the player was apart of the team's starting five during the event or not
 	Starter bool `json:"starter" parquet:"name=starter, type=BOOLEAN"`
 	// MinutesPlayed is minutes played during the event

--- a/dataprovider/basketballreference/nba/model/basic_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/model/basic_box_score_stats.go
@@ -9,21 +9,21 @@ type NBABasicBoxScoreStats struct {
 	// PullTimestampParquet is the fetch timestamp (in milliseconds)
 	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
 	// EventID is the parsed event id from the box score link of the matchup
-	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY"`
+	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// EventDate is the timestamp associated with a given event
 	EventDate time.Time `json:"event_date"`
 	// EventDateParquet is the timestamp associated with a given event (in days)
 	EventDateParquet int32 `json:"-" parquet:"name=event_date, type=INT32, convertedtype=DATE, logicaltype=DATE"`
 	// Team is the player's team name
-	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY"`
+	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Opponent is the opposing team name
-	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY"`
+	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayerID is the player's id extracted from the player's basketball-reference profile url
-	PlayerID string `json:"player_id" parquet:"name=player_id, type=BYTE_ARRAY"`
+	PlayerID string `json:"player_id" parquet:"name=player_id, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Player is the player's name
-	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY"`
+	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayerLink is the link to the player's basketball-reference profile
-	PlayerLink string `json:"player_link" parquet:"name=player_link, type=BYTE_ARRAY"`
+	PlayerLink string `json:"player_link" parquet:"name=player_link, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Starter is whether the player was apart of the team's starting five during the event or not
 	Starter bool `json:"starter" parquet:"name=starter, type=BOOLEAN"`
 	// MinutesPlayed is minutes played during the event

--- a/dataprovider/basketballreference/nba/model/matchup.go
+++ b/dataprovider/basketballreference/nba/model/matchup.go
@@ -9,21 +9,21 @@ type NBAMatchup struct {
 	// PullTimestampParquet is the fetch timestamp (in milliseconds)
 	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
 	// EventID is the parsed event id from the box score link of the matchup
-	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY"`
+	EventID string `json:"event_id" parquet:"name=event_id, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// EventDate is the timestamp associated with a given event
 	EventDate time.Time `json:"event_date"`
 	// EventDateParquet is the timestamp associated with a given event (in days)
 	EventDateParquet int32 `json:"-" parquet:"name=event_date, type=INT32, convertedtype=DATE, logicaltype=DATE"`
 	// AwayTeam is the away team's name
-	AwayTeam string `json:"away_team" parquet:"name=away_team, type=BYTE_ARRAY"`
+	AwayTeam string `json:"away_team" parquet:"name=away_team, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// HomeTeam is the home team's name
-	HomeTeam string `json:"home_team" parquet:"name=home_team, type=BYTE_ARRAY"`
+	HomeTeam string `json:"home_team" parquet:"name=home_team, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// HomeScore is the home team's final score
 	HomeScore int32 `json:"home_score" parquet:"name=home_score, type=INT32"`
 	// AwayScore is the away team's final score
 	AwayScore int32 `json:"away_score" parquet:"name=away_score, type=INT32"`
 	// BoxScoreLink is the link to box score for related to the event
-	BoxScoreLink string `json:"box_score_link" parquet:"name=box_score_link, type=BYTE_ARRAY"`
+	BoxScoreLink string `json:"box_score_link" parquet:"name=box_score_link, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// AwayQ1Total is the away team's Q1 points scored
 	AwayQ1Total int32 `json:"away_q1_total" parquet:"name=away_q1_total, type=INT32"`
 	// AwayQ2Total is the away team's Q2 points scored
@@ -41,9 +41,9 @@ type NBAMatchup struct {
 	// HomeQ4Total is the home team's Q4 points scored
 	HomeQ4Total int32 `json:"home_q4_total" parquet:"name=home_q4_total, type=INT32"`
 	// HomeTeamLink is the link to the home team's basketball-reference profile page
-	HomeTeamLink string `json:"home_team_link" parquet:"name=home_team_link, type=BYTE_ARRAY"`
+	HomeTeamLink string `json:"home_team_link" parquet:"name=home_team_link, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// AwayTeamLink is the link to the away team's basketball-reference profile page
-	AwayTeamLink string `json:"away_team_link" parquet:"name=away_team_link, type=BYTE_ARRAY"`
+	AwayTeamLink string `json:"away_team_link" parquet:"name=away_team_link, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Loser is the losing team's name
-	Loser string `json:"loser" parquet:"name=loser, type=BYTE_ARRAY"`
+	Loser string `json:"loser" parquet:"name=loser, type=BYTE_ARRAY, convertedtype=UTF8"`
 }

--- a/dataprovider/foxsports/model/matchup.go
+++ b/dataprovider/foxsports/model/matchup.go
@@ -17,17 +17,17 @@ type Matchup struct {
 	// EventStatus the numerical representation of the event status e.g. 3
 	EventStatus int32 `json:"event_status" parquet:"name=event_status, type=INT32"`
 	// StatusLine the string representation of the event status e.g. FINAL
-	StatusLine string `json:"status_line" parquet:"name=status_line, type=BYTE_ARRAY"`
+	StatusLine string `json:"status_line" parquet:"name=status_line, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// HomeTeamID is the home team's ID e.g. 21
 	HomeTeamID int64 `json:"home_team_id" parquet:"name=home_team_id, type=INT64"`
 	// HomeTeamAbbreviation is the abbreviation of the home team's name e.g. ATL
-	HomeTeamAbbreviation string `json:"home_team_abbreviation" parquet:"name=home_team_abbreviation, type=BYTE_ARRAY"`
+	HomeTeamAbbreviation string `json:"home_team_abbreviation" parquet:"name=home_team_abbreviation, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// HomeTeamNameLong is the home team's longer name but not the full name e.g. Braves
-	HomeTeamNameLong string `json:"home_team_name_long" parquet:"name=home_team_name_long, type=BYTE_ARRAY"`
+	HomeTeamNameLong string `json:"home_team_name_long" parquet:"name=home_team_name_long, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// HomeTeamNameFull is the home team's full name e.g. Atlanta Braves
-	HomeTeamNameFull string `json:"home_team_name_full" parquet:"name=home_team_name_full, type=BYTE_ARRAY"`
+	HomeTeamNameFull string `json:"home_team_name_full" parquet:"name=home_team_name_full, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// HomeRecord is the home team's record at time of request e.g. 69-37
-	HomeRecord string `json:"home_record" parquet:"name=home_record, type=BYTE_ARRAY"`
+	HomeRecord string `json:"home_record" parquet:"name=home_record, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// HomeScore is the home team's score at time of request e.g. 12
 	HomeScore int32 `json:"home_score" parquet:"name=home_score, type=INT32"`
 	// HomeRank is an optional rank. The values are expected for some NCAAB teams
@@ -35,13 +35,13 @@ type Matchup struct {
 	// AwayTeamID is the away team's ID e.g. 8
 	AwayTeamID int64 `json:"away_team_id" parquet:"name=away_team_id, type=INT64"`
 	// AwayTeamAbbreviation is the abbreviation of the away team's name e.g. LAA
-	AwayTeamAbbreviation string `json:"away_team_abbreviation" parquet:"name=away_team_abbreviation, type=BYTE_ARRAY"`
+	AwayTeamAbbreviation string `json:"away_team_abbreviation" parquet:"name=away_team_abbreviation, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// AwayTeamNameLong is the away team's longer name but not the full name e.g. Angels
-	AwayTeamNameLong string `json:"away_team_name_long" parquet:"name=away_team_name_long, type=BYTE_ARRAY"`
+	AwayTeamNameLong string `json:"away_team_name_long" parquet:"name=away_team_name_long, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// AwayTeamNameFull is the away team's full name e.g. Los Angeles Angels
-	AwayTeamNameFull string `json:"away_team_name_full" parquet:"name=away_team_name_full, type=BYTE_ARRAY"`
+	AwayTeamNameFull string `json:"away_team_name_full" parquet:"name=away_team_name_full, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// AwayRecord is the away team's record at time of request e.g. 56-53
-	AwayRecord string `json:"away_record" parquet:"name=away_record, type=BYTE_ARRAY"`
+	AwayRecord string `json:"away_record" parquet:"name=away_record, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// AwayScore is the away team's score at time of request e.g. 5
 	AwayScore int32 `json:"away_score" parquet:"name=away_score, type=INT32"`
 	// AwayRank is an optional rank. The values are expected for some NCAAB teams

--- a/dataprovider/foxsports/model/mlb_batting_box_score_stats.go
+++ b/dataprovider/foxsports/model/mlb_batting_box_score_stats.go
@@ -17,17 +17,17 @@ type MLBBattingBoxScoreStats struct {
 	// TeamID is the player's team's ID e.g. 21
 	TeamID int64 `json:"team_id" parquet:"name=team_id, type=INT64"`
 	// Team is the player's team name e.g. Atlanta Braves
-	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY"`
+	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// OpponentID is the opposing team's team id
 	OpponentID int64 `json:"opponent_id" parquet:"name=opponent_id, type=INT64"`
 	// Opponent is the opposing team name
-	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY"`
+	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayerID is the player's id
 	PlayerID int64 `json:"player_id" parquet:"name=player_id, type=INT64"`
 	// Player is the player's name
-	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY"`
+	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Position is the player's position
-	Position string `json:"position" parquet:"name=position, type=BYTE_ARRAY"`
+	Position string `json:"position" parquet:"name=position, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// AtBat (AB) - https://www.mlb.com/glossary/standard-stats/at-bat
 	AtBat int32 `json:"at_bat" parquet:"name=at_bat, type=INT32"`
 	// Runs (R) - https://www.mlb.com/glossary/standard-stats/run

--- a/dataprovider/foxsports/model/mlb_pitching_box_score_stats.go
+++ b/dataprovider/foxsports/model/mlb_pitching_box_score_stats.go
@@ -17,17 +17,17 @@ type MLBPitchingBoxScoreStats struct {
 	// TeamID is the player's team's ID e.g. 21
 	TeamID int64 `json:"team_id" parquet:"name=team_id, type=INT64"`
 	// Team is the player's team name e.g. Atlanta Braves
-	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY"`
+	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// OpponentID is the opposing team's team id
 	OpponentID int64 `json:"opponent_id" parquet:"name=opponent_id, type=INT64"`
 	// Opponent is the opposing team name
-	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY"`
+	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayerID is the player's id
 	PlayerID int64 `json:"player_id" parquet:"name=player_id, type=INT64"`
 	// Player is the player's name
-	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY"`
+	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Record is starting pitcher's record
-	Record *string `json:"record" parquet:"name=record, type=BYTE_ARRAY"`
+	Record *string `json:"record" parquet:"name=record, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PitchingOrder - The sequence of pitchers who played during the event per team (starting from 1)
 	PitchingOrder int32 `json:"pitching_order" parquet:"name=pitching_order, type=INT32"`
 	// InningsPitched (IP) - https://www.mlb.com/glossary/standard-stats/innings-pitched

--- a/dataprovider/foxsports/model/nba_box_score_stats.go
+++ b/dataprovider/foxsports/model/nba_box_score_stats.go
@@ -17,17 +17,17 @@ type NBABoxScoreStats struct {
 	// TeamID is the player's team's ID e.g. 8
 	TeamID int64 `json:"team_id" parquet:"name=team_id, type=INT64"`
 	// Team is the player's team name e.g. Atlanta Hawks
-	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY"`
+	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// OpponentID is the opposing team's team id
 	OpponentID int64 `json:"opponent_id" parquet:"name=opponent_id, type=INT64"`
 	// Opponent is the opposing team name
-	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY"`
+	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// PlayerID is the player's id
 	PlayerID int64 `json:"player_id" parquet:"name=player_id, type=INT64"`
 	// Player is the player's name
-	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY"`
+	Player string `json:"player" parquet:"name=player, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Position is the player's position
-	Position string `json:"position" parquet:"name=position, type=BYTE_ARRAY"`
+	Position string `json:"position" parquet:"name=position, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// Starter is whether the player was apart of the team's starting five during the event or not
 	Starter bool `json:"starter" parquet:"name=starter, type=BOOLEAN"`
 	// MinutesPlayed is minutes played during the event


### PR DESCRIPTION
## Context
`BYTE_ARRAY` type fields without `convertedtype=UTF8` within their tag resolve as blob instead of varchar:
```go
type Test struct {
	Name  string `parquet:"name=name, type=BYTE_ARRAY, convertedtype=UTF8, encoding=PLAIN_DICTIONARY"`
	Name2 string `parquet:"name=name2, type=BYTE_ARRAY, convertedtype=UTF8"`
	Name3 string `parquet:"name=name3, type=BYTE_ARRAY"`
}
...
x := Test{
  Name:  "foo",
  Name2: "foo",
  Name3: "foo",
}
// Write to parquet file called test.parquet using github.com/xitongsys/parquet-go
```

Read `test.parquet` using duckdb:
```sql
select * from 'test.parquet';
┌─────────┬─────────┬───────┐
│  name   │  name2  │ name3 │
│ varchar │ varchar │ blob  │
├─────────┼─────────┼───────┤
│ foo     │ foo     │ foo   │
└─────────┴─────────┴───────┘
```

### Added
- Added `convertedtype=UTF8` to all parquet string fields' tag