### PR TITLE
Mockery usage: <package_name> --> <package_name>_test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Updated package name for `util/sportsreference/base_runner_test.go` from `sportsreferenceutil` to `sportsreferenceutil_test`
 
 ## [0.7.1] - 2025-04-22
 ### Added

--- a/util/sportsreference/base_runner_test.go
+++ b/util/sportsreference/base_runner_test.go
@@ -1,6 +1,6 @@
 //go:build unit
 
-package sportsreferenceutil
+package sportsreferenceutil_test
 
 import (
 	"reflect"
@@ -9,16 +9,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
-
+	sportsreferenceutil "github.com/lightning-dabbler/sportscrape/util/sportsreference"
 	mocksportsreferenceutil "github.com/lightning-dabbler/sportscrape/util/sportsreference/mocks"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestMatchupRunnerStructure verifies MatchupRunner embeds Runner properly
 func TestMatchupRunnerStructure(t *testing.T) {
 	// Verify MatchupRunner embeds Runner
-	runner := MatchupRunner{
-		Runner: Runner{
+	runner := sportsreferenceutil.MatchupRunner{
+		Runner: sportsreferenceutil.Runner{
 			Timeout: 5 * time.Second,
 			Debug:   true,
 		},
@@ -87,8 +87,8 @@ func TestBoxScoreRunnerGetBoxScoresStats(t *testing.T) {
 				mockprocessor.EXPECT().GetSegmentBoxScoreStats(matchup).Return([]interface{}{2 * matchup.(int), 2 * matchup.(int)})
 			}
 
-			runner := &BoxScoreRunner{
-				Runner: Runner{
+			runner := &sportsreferenceutil.BoxScoreRunner{
+				Runner: sportsreferenceutil.Runner{
 					Timeout: 1 * time.Second,
 				},
 				Concurrency: tc.concurrency,
@@ -124,7 +124,7 @@ func TestBoxScoreRunnerWorker(t *testing.T) {
 	for _, matchup := range matchups {
 		mockprocessor.EXPECT().GetSegmentBoxScoreStats(matchup).Return([]interface{}{matchup})
 	}
-	runner := &BoxScoreRunner{
+	runner := &sportsreferenceutil.BoxScoreRunner{
 		Processor: mockprocessor,
 	}
 
@@ -181,7 +181,7 @@ func TestRunnerStructureAndOptions(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			runner := Runner{
+			runner := sportsreferenceutil.Runner{
 				Timeout: tc.timeout,
 				Debug:   tc.debug,
 			}


### PR DESCRIPTION
## Context 
This change aims to circumvent the following log lines when running `go mod tidy` in projects referencing this package:
```console
$ go mod tidy
go: finding module for package github.com/lightning-dabbler/sportscrape/util/sportsreference/mocks
go: *** imports
        github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb imports
        github.com/lightning-dabbler/sportscrape/util/sportsreference tested by
        github.com/lightning-dabbler/sportscrape/util/sportsreference.test imports
        github.com/lightning-dabbler/sportscrape/util/sportsreference/mocks: module github.com/lightning-dabbler/sportscrape@latest found (v0.7.1), but does not contain package github.com/lightning-dabbler/sportscrape/util/sportsreference/mocks
```