### PR TITLE
Optimize matchup extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Optimize extraction of matchups on baseball-reference and basketball-reference
 
 ## [0.8.1] - 2025-05-14
 ### Fixed

--- a/dataprovider/baseballreference/mlb/batting_box_score_stats.go
+++ b/dataprovider/baseballreference/mlb/batting_box_score_stats.go
@@ -98,7 +98,7 @@ func (boxScoreRunner *BattingBoxScoreRunner) GetSegmentBoxScoreStats(matchup int
 	start := time.Now().UTC()
 	var boxScoreStats []interface{}
 	log.Println("Scraping batting Box Score: " + url)
-	doc, err := boxScoreRunner.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
+	doc, err := boxScoreRunner.RetrieveDocument(url, networkHeaders, contentReadySelector)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/dataprovider/baseballreference/mlb/matchups.go
+++ b/dataprovider/baseballreference/mlb/matchups.go
@@ -89,7 +89,7 @@ func (matchupRunner *MatchupRunner) GetMatchups(date string) []interface{} {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	doc, err := matchupRunner.RetrieveDocument(url, networkHeaders, matchupsGameSummariesSelector)
+	doc, err := matchupRunner.RetrieveDocument(url, networkHeaders, contentReadySelector)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/dataprovider/baseballreference/mlb/pitching_box_score_stats.go
+++ b/dataprovider/baseballreference/mlb/pitching_box_score_stats.go
@@ -101,7 +101,7 @@ func (boxScoreRunner *PitchingBoxScoreRunner) GetSegmentBoxScoreStats(matchup in
 	start := time.Now().UTC()
 	var boxScoreStats []interface{}
 	log.Println("Scraping pitching Box Score: " + url)
-	doc, err := boxScoreRunner.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
+	doc, err := boxScoreRunner.RetrieveDocument(url, networkHeaders, contentReadySelector)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/dataprovider/baseballreference/mlb/shared.go
+++ b/dataprovider/baseballreference/mlb/shared.go
@@ -32,11 +32,11 @@ const (
 )
 
 const (
-	waitReadyBoxScoreContentSelector = "#content"
-	headersSelector                  = "thead > tr th"
-	recordSelector                   = "tbody > tr"
-	positionSelector                 = "th"
-	playerSelector                   = positionSelector + " a"
+	contentReadySelector = "#content"
+	headersSelector      = "thead > tr th"
+	recordSelector       = "tbody > tr"
+	positionSelector     = "th"
+	playerSelector       = positionSelector + " a"
 )
 
 func (st StatType) String() string {

--- a/dataprovider/basketballreference/nba/adv_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/adv_box_score_stats.go
@@ -117,7 +117,7 @@ func (boxScoreRunner *AdvBoxScoreRunner) GetSegmentBoxScoreStats(matchup interfa
 	start := time.Now().UTC()
 	var advNBABoxScoreStats []interface{}
 	log.Println("Scraping Advanced Box Score: " + url)
-	doc, err := boxScoreRunner.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
+	doc, err := boxScoreRunner.RetrieveDocument(url, networkHeaders, contentReadySelector)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/dataprovider/basketballreference/nba/basic_box_score_stats.go
+++ b/dataprovider/basketballreference/nba/basic_box_score_stats.go
@@ -189,7 +189,7 @@ func (boxScoreRunner *BasicBoxScoreRunner) GetSegmentBoxScoreStats(matchup inter
 	start := time.Now().UTC()
 	var basicNBABoxScoreStats []interface{}
 	log.Printf("Scraping %s Basic Box Score: %s\n", boxScoreRunner.Period.String(), url)
-	doc, err := boxScoreRunner.RetrieveDocument(url, networkHeaders, waitReadyBoxScoreContentSelector)
+	doc, err := boxScoreRunner.RetrieveDocument(url, networkHeaders, contentReadySelector)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/dataprovider/basketballreference/nba/matchups.go
+++ b/dataprovider/basketballreference/nba/matchups.go
@@ -99,7 +99,7 @@ func (matchupRunner *MatchupRunner) GetMatchups(date string) []interface{} {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	doc, err := matchupRunner.RetrieveDocument(url, networkHeaders, matchupsGameSummariesSelector)
+	doc, err := matchupRunner.RetrieveDocument(url, networkHeaders, contentReadySelector)
 	if err != nil {
 		log.Fatalln(err)
 	}

--- a/dataprovider/basketballreference/nba/shared.go
+++ b/dataprovider/basketballreference/nba/shared.go
@@ -25,12 +25,12 @@ var networkHeaders network.Headers = network.Headers(map[string]interface{}{
 
 const (
 	// https://www.basketball-reference.com/boxscores/{event_id}.html
-	waitReadyBoxScoreContentSelector = `#content`
-	boxScoreStatsRecordsSelector     = `tbody > tr`
-	boxScoreStarterHeaders           = `thead > tr:nth-child(2) th`
-	boxScoreReserveHeaders           = `th`
-	boxScorePlayerSelector           = "th"
-	boxScorePlayerLinkSelector       = boxScorePlayerSelector + " > a"
+	contentReadySelector         = "#content"
+	boxScoreStatsRecordsSelector = `tbody > tr`
+	boxScoreStarterHeaders       = `thead > tr:nth-child(2) th`
+	boxScoreReserveHeaders       = `th`
+	boxScorePlayerSelector       = "th"
+	boxScorePlayerLinkSelector   = boxScorePlayerSelector + " > a"
 )
 
 func transformMinutesPlayed(minutesPlayed string) (float32, error) {


### PR DESCRIPTION
## Context
### Fixed
- Optimize extraction of matchups on baseball-reference and basketball-reference

## Issues
1. The basketball-reference NBA matchup extraction of `2025-02-20` did not resolve without "context deadline exceeded" regardless of timeout setting
2. The baseball-reference MLB matchup extraction of `2025-03-11` did not resolve without "context deadline exceeded" regardless of timeout setting

Both dates correspond to periods of no events.

## Resolution
Extractors will only wait for `#content` selector