### PR TITLE
Ignore baseball-reference MLB all-star matchups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MLBProbableStartingPitcher` fox sports data model for probable starting pitcher (#73)
 - Scraping fox sports MLB probable starting pitcher using `MLBProbableStartingPitcherScraper` (#73)
 ### Fixed
-- Ignore baseball-reference MLB all-star matchups
+- Ignore baseball-reference MLB all-star matchups (#74)
 
 ## [0.8.2] - 2025-05-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `MLBMatchupComparison` for fox sports json response for probable starting pitchers (#73)
 - `MLBProbableStartingPitcher` fox sports data model for probable starting pitcher (#73)
 - Scraping fox sports MLB probable starting pitcher using `MLBProbableStartingPitcherScraper` (#73)
+### Fixed
+- Ignore baseball-reference MLB all-star matchups
 
 ## [0.8.2] - 2025-05-17
 ### Fixed

--- a/dataprovider/baseballreference/mlb/matchups.go
+++ b/dataprovider/baseballreference/mlb/matchups.go
@@ -231,10 +231,10 @@ func (matchupRunner *MatchupRunner) GetMatchups(date string) []interface{} {
 	})
 
 	if len(matchups) == 0 {
-		fmt.Printf("No Data Scraped @ %s\n", url)
+		log.Printf("No relevant data scraped @ %s\n", url)
 	} else {
 		diff := time.Now().UTC().Sub(start)
-		fmt.Printf("Scraping of %s Completed in %s\n", url, diff)
+		log.Printf("Scraping of %s Completed in %s\n", url, diff)
 	}
 	return matchups
 }


### PR DESCRIPTION
## Context
Ignore baseball-reference MLB all-star matchups. Fixes https://github.com/lightning-dabbler/sportscrape/issues/72

```go
package main

import (
	"fmt"
	"time"

	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb"
	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballreference/mlb/model"
)

func main() {
	date := "2024-07-16"
	// Instantiate MatchupRunner
	runner := mlb.NewMatchupRunner(
		mlb.WithMatchupTimeout(10 * time.Minute),
	)
	// Retrieve MLB matchups associated with date
	matchups := runner.GetMatchups(date)
	for _, matchup := range matchups {
		fmt.Printf("%#v\n", matchup.(model.MLBMatchup))
	}
}

```


```console
2025/05/28 00:55:43 Scraping Matchups: https://www.baseball-reference.com/boxes?month=7&day=16&year=2024
Retrieving document from: https://www.baseball-reference.com/boxes?month=7&day=16&year=2024
2025/05/28 00:55:44 National League is a team associated with an all-star event. Skipping event date, 2024-07-16, entirely
2025/05/28 00:55:44 No relevant data scraped @ https://www.baseball-reference.com/boxes?month=7&day=16&year=2024
```