### PR TITLE
Baseball savant mlb: Matchup scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Added `MatchupScraper` for baseball savant mlb
+- Added `MatchupScraper` for baseball savant mlb (#84)
 ### Changed
-- Moved `RFC3339ToTime` and `DateStrToTime` to time.go
-- Documentation updates
+- Moved `RFC3339ToTime` and `DateStrToTime` to time.go (#84)
+- Documentation updates (#84)
 
 ## [0.11.0] - 2025-07-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `MatchupScraper` for baseball savant mlb
+### Changed
+- Moved `RFC3339ToTime` and `DateStrToTime` to time.go
+- Documentation updates
 
 ## [0.11.0] - 2025-07-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ func main() {
 - [basketball-reference.com NBA scrape examples](dataprovider/basketballreferencenba/example_test.go)
 - [baseball-reference.com MLB scrape examples](dataprovider/baseballreferencemlb/example_test.go)
 - [foxsports.com scraping examples](dataprovider/foxsports/example_test.go)
+- [baseballsavant.mlb.com scraping examples](dataprovider/baseballsavantmlb/example_test.go)
 
 ## Data providers
 
@@ -75,6 +76,7 @@ func main() {
 | https://www.foxsports.com		   | MLB	| Probable starting pitcher| Full			  | |application/json|✅|
 | https://www.foxsports.com		   | NCAAB	| Matchup				 | Live, Full			  | |application/json|✅|
 | https://www.foxsports.com		   | NFL	| Matchup				 | Live, Full			  | |application/json|✅|
+| https://baseballsavant.mlb.com		   | MLB	| Matchup				 | Live, Full			  | |application/json|✅|
 
 ## Supported Formats
 File formats the constructed data models support on export and import.
@@ -88,7 +90,7 @@ File formats the constructed data models support on export and import.
 Go 1.24 or higher
 
 ### Testing
-This project is using [mockery](https://github.com/vektra/mockery) to mock interfaces.
+This project is using [mockery](https://github.com/vektra/mockery) v3.5.0 to mock interfaces.
 
 To run unit tests:
 ```console

--- a/catalog.go
+++ b/catalog.go
@@ -35,6 +35,10 @@ var (
 	BasketballReferenceNBABoxScoreH2  Feed     = Feed(string(BasketballReference) + " nba h2 box score")
 	BasketballReferenceNBAAdvBoxScore Feed     = Feed(string(BasketballReference) + " nba advanced box score")
 
+	// baseball savant
+	BaseballSavant           Provider = "baseball savant"
+	BaseballSavantMLBMatchup Feed     = Feed(string(BaseballSavant) + " mlb matchup")
+
 	// testing
 	DummyProvider Provider = "dummy provider"
 	DummyFeed     Feed     = Feed(string(DummyProvider) + " dummy feed")

--- a/dataprovider/baseballreferencemlb/scraper_batting_box_score_stats_test.go
+++ b/dataprovider/baseballreferencemlb/scraper_batting_box_score_stats_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetBattingBoxScoreStats(t *testing.T) {
+func TestBattingBoxScoreScraper(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}

--- a/dataprovider/baseballreferencemlb/scraper_matchups.go
+++ b/dataprovider/baseballreferencemlb/scraper_matchups.go
@@ -91,7 +91,7 @@ func (ms *MatchupScraper) Scrape() sportscrape.MatchupOutput {
 	var matchups []interface{}
 	output := sportscrape.MatchupOutput{}
 	var skips int
-	timestamp, err := sportsreference.DateStrToTime(ms.Date)
+	timestamp, err := util.DateStrToTime(ms.Date)
 	if err != nil {
 		output.Error = err
 		return output

--- a/dataprovider/baseballreferencemlb/scraper_matchups_test.go
+++ b/dataprovider/baseballreferencemlb/scraper_matchups_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetMatchups(t *testing.T) {
+func TestMatchupScraper(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip("Skipping integration test")

--- a/dataprovider/baseballreferencemlb/scraper_pitching_box_score_stats_test.go
+++ b/dataprovider/baseballreferencemlb/scraper_pitching_box_score_stats_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetPitchingBoxScoreStats(t *testing.T) {
+func TestPitchingBoxScoreScraper(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}

--- a/dataprovider/baseballsavantmlb/example_test.go
+++ b/dataprovider/baseballsavantmlb/example_test.go
@@ -1,0 +1,33 @@
+package baseballsavantmlb_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb"
+)
+
+// Example for baseballsavantmlb.MatchupScraper
+func ExampleMatchupScraper() {
+	date := "2025-06-25"
+	matchupscraper := baseballsavantmlb.NewMatchupScraper(
+		baseballsavantmlb.MatchupScraperDate(date),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	if err != nil {
+		panic(err)
+	}
+	// Output each statline as pretty json
+	for _, matchup := range matchups {
+		jsonBytes, err := json.MarshalIndent(matchup, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}

--- a/dataprovider/baseballsavantmlb/jsonresponse/matchup.go
+++ b/dataprovider/baseballsavantmlb/jsonresponse/matchup.go
@@ -1,0 +1,49 @@
+package jsonresponse
+
+// https://baseballsavant.mlb.com/schedule?date=2025-6-24
+
+type Matchups struct {
+	Schedule struct {
+		Dates []Date `json:"dates"`
+	} `json:"schedule"`
+}
+
+type Date struct {
+	TotalGames int32  `json:"totalGames"`
+	Games      []Game `json:"games"`
+}
+
+type Game struct {
+	EventID   int64  `json:"gamePk"`   // "gamePk": 777386
+	EventTime string `json:"gameDate"` // "gameDate": "2025-06-24T18:40:00-04:00"
+	Status    struct {
+		DetailedState string `json:"detailedState"` // "detailedState": "Final"
+	} `json:"status"`
+	Season            string `json:"season"`            // "season": "2025"
+	GameType          string `json:"gameType"`          // "gameType": "R"
+	SeriesDescription string `json:"seriesDescription"` // "seriesDescription": "Regular Season"
+	GamesInSeries     int32  `json:"gamesInSeries"`     // "gamesInSeries": 3
+	SeriesGameNumber  int32  `json:"seriesGameNumber"`  // "seriesGameNumber": 1
+	Teams             struct {
+		Away Team `json:"away"`
+		Home Team `json:"home"`
+	} `json:"teams"`
+}
+
+type Team struct {
+	LeagueRecord struct {
+		Wins   int32 `json:"wins"`   // "wins": 44
+		Losses int32 `json:"losses"` // "losses": 24
+	} `json:"leagueRecord"`
+	Score    *int32 `json:"score"`    // "score": 4
+	IsWinner *bool  `json:"isWinner"` // "isWinner": false,
+	Team     struct {
+		ID           int64  `json:"id"`           // "id": 116
+		Name         string `json:"name"`         // "name": "Detroit Tigers"
+		Abbreviation string `json:"abbreviation"` // "abbreviation": "NYM"
+	} `json:"team"`
+	ProbablePitcher *struct {
+		ID   int64  `json:"id"`       // "id": 694973,
+		Name string `json:"fullName"` // "fullName": "Paul Skenes"
+	} `json:"probablePitcher"`
+}

--- a/dataprovider/baseballsavantmlb/model/matchup.go
+++ b/dataprovider/baseballsavantmlb/model/matchup.go
@@ -1,0 +1,63 @@
+package model
+
+import "time"
+
+// Matchup represents the data model for MLB matchups scraped from baseballsavant.mlb.com
+type Matchup struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// PullTimestampParquet is the fetch timestamp (in milliseconds)
+	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// EventID is a unique ID that maps to the matchup e.g. 86833
+	EventID int64 `json:"event_id" parquet:"name=event_id, type=INT64"`
+	// EventTime is the timestamp associated with the matchup
+	EventTime time.Time `json:"event_time"`
+	// EventTimeParquet is the timestamp associated with the matchup (in milliseconds)
+	EventTimeParquet int64 `json:"-" parquet:"name=event_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// Status is the string representation of the event status e.g. Final
+	Status string `json:"status" parquet:"name=status, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// HomeTeamID is the home team's ID
+	HomeTeamID int64 `json:"home_team_id" parquet:"name=home_team_id, type=INT64"`
+	// HomeTeamAbbreviation is the abbreviation of the home team's name e.g. DET
+	HomeTeamAbbreviation string `json:"home_team_abbreviation" parquet:"name=home_team_abbreviation, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// HomeTeamName is the home team's full name e.g. Detroit Tigers
+	HomeTeamName string `json:"home_team_name" parquet:"name=home_team_name_full, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// HomeRecord is the home team's number of wins
+	HomeWins int32 `json:"home_wins" parquet:"name=home_wins, type=INT32"`
+	// HomeLosses is the home team's number of losses
+	HomeLosses int32 `json:"home_losses" parquet:"name=home_losses, type=INT32"`
+	// HomeScore is the home team's score at time of request
+	HomeScore *int32 `json:"home_score" parquet:"name=home_score, type=INT32"`
+	// HomeStartingPitcherID is the player id for the home team's starting pitcher (nillable because it may not be yet announced when fetching a scheduled event)
+	HomeStartingPitcherID *int64 `json:"home_starting_pitcher_id" parquet:"name=home_starting_pitcher_id, type=INT64"`
+	// HomeStartingPitcher the name of the home team's starting pitcher
+	HomeStartingPitcher *string `json:"home_starting_pitcher" parquet:"name=home_starting_pitcher, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// AwayTeamID is the away team's ID e.g. 8
+	AwayTeamID int64 `json:"away_team_id" parquet:"name=away_team_id, type=INT64"`
+	// AwayTeamAbbreviation is the abbreviation of the away team's name e.g. LAA
+	AwayTeamAbbreviation string `json:"away_team_abbreviation" parquet:"name=away_team_abbreviation, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// AwayTeamName is the away team's full name
+	AwayTeamName string `json:"away_team_name" parquet:"name=away_team_name_full, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// AwayRecord is the away team's number of wins
+	AwayWins int32 `json:"away_wins" parquet:"name=away_wins, type=INT32"`
+	// AwayLosses is the away team's number of losses
+	AwayLosses int32 `json:"away_losses" parquet:"name=away_losses, type=INT32"`
+	// AwayScore is the away team's score at time of request
+	AwayScore *int32 `json:"away_score" parquet:"name=away_score, type=INT32"`
+	// AwayStartingPitcherID is the player id for the away team's starting pitcher (nillable because it may not be yet announced when fetching a scheduled event)
+	AwayStartingPitcherID *int64 `json:"away_starting_pitcher_id" parquet:"name=away_starting_pitcher_id, type=INT64"`
+	// AwayStartingPitcher the name of the away team's starting pitcher
+	AwayStartingPitcher *string `json:"away_starting_pitcher" parquet:"name=away_starting_pitcher, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// Loser is an optional team id associated with the loser. Optional because some games could be live a loser will not be determined until the matchup is complete.
+	Loser *int64 `json:"loser" parquet:"name=loser, type=INT64"`
+	// GameType is an abbreviation that indicates the type of event taking place (e.g. "R", "S", "W", etc.)
+	GameType string `json:"game_type" parquet:"name=game_type, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// SeriesDescription acts as supplemental information for GameType (e.g. "Regular Season", "Spring Training", "World Series", etc.)
+	SeriesDescription string `json:"series_description" parquet:"name=series_description, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// GamesInSeries is the number of games being played in this series of matchup
+	GamesInSeries int32 `json:"games_in_series" parquet:"name=games_in_series, type=INT32"`
+	// SeriesGameNumber is the series game number of the event
+	SeriesGameNumber int32 `json:"series_game_number" parquet:"name=series_game_number, type=INT32"`
+	// Season - e.g. 2025
+	Season int32 `json:"season" parquet:"name=season, type=INT32"`
+}

--- a/dataprovider/baseballsavantmlb/scraper_matchups.go
+++ b/dataprovider/baseballsavantmlb/scraper_matchups.go
@@ -1,0 +1,153 @@
+package baseballsavantmlb
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/jsonresponse"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	"github.com/lightning-dabbler/sportscrape/util/request"
+	"github.com/xitongsys/parquet-go/types"
+)
+
+// MatchupScraperOption defines a configuration option for the scraper
+type MatchupScraperOption func(*MatchupScraper)
+
+// MatchupScraperDate sets the date option
+func MatchupScraperDate(date string) MatchupScraperOption {
+	return func(s *MatchupScraper) {
+		s.Date = date
+	}
+}
+
+// NewMatchupScraper creates a new MatchupScraper with the provided options
+func NewMatchupScraper(options ...MatchupScraperOption) *MatchupScraper {
+	s := &MatchupScraper{}
+
+	// Apply all options
+	for _, option := range options {
+		option(s)
+	}
+	s.Init()
+
+	return s
+}
+
+type MatchupScraper struct {
+	Date string
+}
+
+func (s MatchupScraper) Init() {
+	if s.Date == "" {
+		log.Fatalln("Date is a required argument")
+	}
+}
+
+func (s MatchupScraper) Provider() sportscrape.Provider {
+	return sportscrape.BaseballSavant
+}
+
+func (s MatchupScraper) Feed() sportscrape.Feed {
+	return sportscrape.BaseballSavantMLBMatchup
+}
+
+func (s MatchupScraper) Scrape() sportscrape.MatchupOutput {
+	var matchups []interface{}
+	output := sportscrape.MatchupOutput{}
+
+	url, err := ConstructMatchupURL(s.Date)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+
+	var jsonobj jsonresponse.Matchups
+	pullTimestamp := time.Now().UTC()
+	response, err := request.Get(url)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+	err = json.Unmarshal(body, &jsonobj)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+
+	for _, game := range jsonobj.Schedule.Dates[0].Games {
+		season, err := util.TextToInt32(game.Season)
+		if err != nil {
+			log.Printf("error converting season from string to int32: %s", game.Season)
+			output.Error = err
+			return output
+		}
+		eventTime, err := util.RFC3339ToTime(game.EventTime)
+		if err != nil {
+			log.Printf("error parsing EventTime: %s", game.EventTime)
+			output.Error = err
+			return output
+		}
+		matchup := model.Matchup{
+			PullTimestamp:        pullTimestamp,
+			PullTimestampParquet: types.TimeToTIMESTAMP_MILLIS(pullTimestamp, true),
+			EventTime:            eventTime,
+			EventTimeParquet:     types.TimeToTIMESTAMP_MILLIS(eventTime, true),
+			EventID:              game.EventID,
+			Status:               game.Status.DetailedState,
+
+			HomeTeamID:           game.Teams.Home.Team.ID,
+			HomeTeamAbbreviation: game.Teams.Home.Team.Abbreviation,
+			HomeTeamName:         game.Teams.Home.Team.Name,
+			HomeWins:             game.Teams.Home.LeagueRecord.Wins,
+			HomeLosses:           game.Teams.Home.LeagueRecord.Losses,
+
+			AwayTeamID:           game.Teams.Away.Team.ID,
+			AwayTeamAbbreviation: game.Teams.Away.Team.Abbreviation,
+			AwayTeamName:         game.Teams.Away.Team.Name,
+			AwayWins:             game.Teams.Away.LeagueRecord.Wins,
+			AwayLosses:           game.Teams.Away.LeagueRecord.Losses,
+
+			GameType:          game.GameType,
+			SeriesDescription: game.SeriesDescription,
+			GamesInSeries:     game.GamesInSeries,
+			SeriesGameNumber:  game.SeriesGameNumber,
+			Season:            season,
+		}
+
+		if game.Teams.Home.Score != nil {
+			matchup.HomeScore = game.Teams.Home.Score
+		}
+		if game.Teams.Home.ProbablePitcher != nil {
+			matchup.HomeStartingPitcherID = &game.Teams.Home.ProbablePitcher.ID
+			matchup.HomeStartingPitcher = &game.Teams.Home.ProbablePitcher.Name
+		}
+
+		if game.Teams.Away.Score != nil {
+			matchup.AwayScore = game.Teams.Away.Score
+		}
+		if game.Teams.Away.ProbablePitcher != nil {
+			matchup.AwayStartingPitcherID = &game.Teams.Away.ProbablePitcher.ID
+			matchup.AwayStartingPitcher = &game.Teams.Away.ProbablePitcher.Name
+		}
+
+		if game.Teams.Away.IsWinner != nil && *game.Teams.Away.IsWinner {
+			matchup.Loser = &game.Teams.Away.Team.ID
+		}
+		if game.Teams.Home.IsWinner != nil && *game.Teams.Home.IsWinner {
+			matchup.Loser = &game.Teams.Home.Team.ID
+		}
+
+		matchups = append(matchups, matchup)
+	}
+	output.Output = matchups
+	return output
+}

--- a/dataprovider/baseballsavantmlb/scraper_matchups_test.go
+++ b/dataprovider/baseballsavantmlb/scraper_matchups_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+package baseballsavantmlb
+
+import (
+	"testing"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchupScraper_NBA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	matchupscraper := NewMatchupScraper(
+		MatchupScraperDate("2024-10-18"),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	assert.NoError(t, err)
+	n_matchups := len(matchups)
+	assert.Equal(t, 2, n_matchups, "2 events")
+	testMatchup := matchups[1].(model.Matchup)
+	assert.Equal(t, int64(775311), testMatchup.EventID)
+	assert.Equal(t, "Final", testMatchup.Status)
+
+	assert.Equal(t, int64(114), testMatchup.HomeTeamID)
+	assert.Equal(t, "CLE", testMatchup.HomeTeamAbbreviation)
+	assert.Equal(t, "Cleveland Guardians", testMatchup.HomeTeamName)
+	assert.Equal(t, "Gavin Williams", *testMatchup.HomeStartingPitcher)
+	assert.Equal(t, int64(668909), *testMatchup.HomeStartingPitcherID)
+	assert.Equal(t, int32(1), testMatchup.HomeWins)
+	assert.Equal(t, int32(3), testMatchup.HomeLosses)
+	assert.Equal(t, int32(6), *testMatchup.HomeScore)
+
+	assert.Equal(t, int64(147), testMatchup.AwayTeamID)
+	assert.Equal(t, "NYY", testMatchup.AwayTeamAbbreviation)
+	assert.Equal(t, "New York Yankees", testMatchup.AwayTeamName)
+	assert.Equal(t, "Luis Gil", *testMatchup.AwayStartingPitcher)
+	assert.Equal(t, int64(661563), *testMatchup.AwayStartingPitcherID)
+	assert.Equal(t, int32(3), testMatchup.AwayWins)
+	assert.Equal(t, int32(1), testMatchup.AwayLosses)
+	assert.Equal(t, int32(8), *testMatchup.AwayScore)
+
+	assert.Equal(t, int64(147), *testMatchup.Loser)
+	assert.Equal(t, "L", testMatchup.GameType)
+	assert.Equal(t, "League Championship Series", testMatchup.SeriesDescription)
+	assert.Equal(t, int32(7), testMatchup.GamesInSeries)
+	assert.Equal(t, int32(4), testMatchup.SeriesGameNumber)
+	assert.Equal(t, int32(2024), testMatchup.Season)
+
+}

--- a/dataprovider/baseballsavantmlb/url.go
+++ b/dataprovider/baseballsavantmlb/url.go
@@ -1,0 +1,29 @@
+package baseballsavantmlb
+
+import (
+	"strconv"
+
+	"github.com/lightning-dabbler/sportscrape/util"
+)
+
+const (
+	URL = "https://baseballsavant.mlb.com"
+)
+
+// ConstructMatchupURL
+// https://baseballsavant.mlb.com/schedule?date=2025-6-24
+func ConstructMatchupURL(date string) (string, error) {
+	timestamp, err := util.DateStrToTime(date)
+	if err != nil {
+		return "", err
+
+	}
+	datestr := timestamp.Format("2006-1-2")
+	return URL + "/schedule?date=" + datestr, nil
+}
+
+// ConstructEventDataURL
+// https://baseballsavant.mlb.com/gf?game_pk=777386
+func ConstructEventDataURL(eventid int64) string {
+	return URL + "/gf?game_pk=" + strconv.FormatInt(eventid, 10)
+}

--- a/dataprovider/basketballreferencenba/scraper_adv_box_score_stats_test.go
+++ b/dataprovider/basketballreferencenba/scraper_adv_box_score_stats_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetAdvBoxScoreStats(t *testing.T) {
+func TestAdvBoxScoreScraper(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}

--- a/dataprovider/basketballreferencenba/scraper_basic_box_score_stats_test.go
+++ b/dataprovider/basketballreferencenba/scraper_basic_box_score_stats_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetFullBasicBoxScoreStats(t *testing.T) {
+func TestBasicBoxScoreScraper(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}
@@ -102,7 +102,7 @@ func TestGetFullBasicBoxScoreStats(t *testing.T) {
 	assert.Equal(t, expectedHomeDNP, numHomeDNP, "Assert number of home players on LA Lakers that did not play")
 }
 
-func TestGetH1BasicBoxScoreStats(t *testing.T) {
+func TestBasicBoxScoreScraper_H1(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}
@@ -232,7 +232,7 @@ func TestGetH1BasicBoxScoreStats(t *testing.T) {
 	assert.True(t, playerToTest["Gabe Vincent"], "Gabe Vincent's stats were collected")
 }
 
-func TestGetQ3BasicBoxScoreStats(t *testing.T) {
+func TestBasicBoxScoreScraper_Q3(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}

--- a/dataprovider/basketballreferencenba/scraper_matchups.go
+++ b/dataprovider/basketballreferencenba/scraper_matchups.go
@@ -100,7 +100,7 @@ func (ms MatchupScraper) Feed() sportscrape.Feed {
 func (ms *MatchupScraper) Scrape() sportscrape.MatchupOutput {
 	var matchups []interface{}
 	output := sportscrape.MatchupOutput{}
-	timestamp, err := sportsreference.DateStrToTime(ms.Date)
+	timestamp, err := util.DateStrToTime(ms.Date)
 	if err != nil {
 		output.Error = err
 		return output

--- a/dataprovider/basketballreferencenba/scraper_matchups_test.go
+++ b/dataprovider/basketballreferencenba/scraper_matchups_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/xitongsys/parquet-go/writer"
 )
 
-func TestGetMatchups(t *testing.T) {
+func TestMatchupScraper(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip("Skipping integration test")

--- a/dataprovider/foxsports/scraper_matchup_test.go
+++ b/dataprovider/foxsports/scraper_matchup_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetNBAMatchup(t *testing.T) {
+func TestMatchupScraper_NBA(t *testing.T) {
 	// https://api.foxsports.com/bifrost/v1/nba/scoreboard/segment/20250406?apikey=jE7yBJVRNAwdDesMgTzTXUUSx1It41Fq
 	if testing.Short() {
 		t.Skip("Skipping integration test")
@@ -54,7 +54,7 @@ func TestGetNBAMatchup(t *testing.T) {
 
 }
 
-func TestGetMLBMatchup(t *testing.T) {
+func TestMatchupScraper_MLB(t *testing.T) {
 	// https://api.foxsports.com/bifrost/v1/mlb/scoreboard/segment/20241018?apikey=jE7yBJVRNAwdDesMgTzTXUUSx1It41Fq
 	if testing.Short() {
 		t.Skip("Skipping integration test")
@@ -97,7 +97,7 @@ func TestGetMLBMatchup(t *testing.T) {
 
 }
 
-func TestGetNFLMatchup(t *testing.T) {
+func TestMatchupScraper_NFL(t *testing.T) {
 	// https://api.foxsports.com/bifrost/v1/nfl/scoreboard/segment/2024-4-2?apikey=jE7yBJVRNAwdDesMgTzTXUUSx1It41Fq
 	if testing.Short() {
 		t.Skip("Skipping integration test")
@@ -139,7 +139,7 @@ func TestGetNFLMatchup(t *testing.T) {
 	assert.Equal(t, true, testMatchup.IsPlayoff)
 }
 
-func TestGetNCAABMatchup(t *testing.T) {
+func TestMatchupScraper_NCAAB(t *testing.T) {
 	// https://api.foxsports.com/bifrost/v1/cbk/scoreboard/segment/20250405?groupId=2&apikey=jE7yBJVRNAwdDesMgTzTXUUSx1It41Fq
 	if testing.Short() {
 		t.Skip("Skipping integration test")

--- a/dataprovider/foxsports/scraper_mlb_probable_starting_pitcher_test.go
+++ b/dataprovider/foxsports/scraper_mlb_probable_starting_pitcher_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMLBProbableStartingPitcher(t *testing.T) {
+func TestMLBProbableStartingPitcherScraper(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}

--- a/util/sportsreference/util.go
+++ b/util/sportsreference/util.go
@@ -6,25 +6,6 @@ import (
 	"time"
 )
 
-const (
-	// time parse date template
-	dateLayout = "2006-01-02"
-)
-
-// DateStrToTime takes in a date string in the form 2024-01-25
-//
-// Parameter:
-//   - date: the date string to parse
-//
-// Returns a time.Time{} and nilable error
-func DateStrToTime(date string) (time.Time, error) {
-	dateParse, err := time.Parse(dateLayout, date)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("could not parse '%s': %w", date, err)
-	}
-	return dateParse, nil
-}
-
 // EventDate takes in a date string in the form 2024-01-25
 //
 // Parameter:
@@ -37,7 +18,7 @@ func EventDate(date string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("An issue arose loading timezone: %w", err)
 	}
 
-	dateParse, err := time.ParseInLocation(dateLayout, date, loc)
+	dateParse, err := time.ParseInLocation(time.DateOnly, date, loc)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("Could not parse '%s': %w", date, err)
 	}

--- a/util/sportsreference/util_test.go
+++ b/util/sportsreference/util_test.go
@@ -9,45 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDateStrToTime(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected time.Time
-		isError  bool
-	}{
-		{
-			name:     "valid date",
-			input:    "2024-01-25",
-			expected: time.Date(2024, 1, 25, 0, 0, 0, 0, time.UTC),
-			isError:  false,
-		},
-		{
-			name:    "invalid date format",
-			input:   "01-25-2024",
-			isError: true,
-		},
-		{
-			name:    "empty string",
-			input:   "",
-			isError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := DateStrToTime(tt.input)
-			if tt.isError {
-				assert.Error(t, err)
-				return
-			}
-
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestEventDate(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/util/string.go
+++ b/util/string.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // re is the regex compilation of one or more spaces
@@ -81,13 +80,4 @@ func TextToFloat32(str string) (float32, error) {
 		return 0, fmt.Errorf("Could not convert %s to float32: %w", str, err)
 	}
 	return float32(val), nil
-}
-
-// RFC3339ToTime converts a RFC 3339 timestamp string to time.Time
-func RFC3339ToTime(str string) (time.Time, error) {
-	timestamp, err := time.Parse(time.RFC3339, str)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("Could not convert RFC3339 string %s to time.Time: %w", str, err)
-	}
-	return timestamp, nil
 }

--- a/util/string_test.go
+++ b/util/string_test.go
@@ -4,7 +4,6 @@ package util
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -239,38 +238,6 @@ func TestTextToFloat32(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestRFC3339ToTime(t *testing.T) {
-	tests := []struct {
-		name     string
-		isError  bool
-		input    string
-		expected time.Time
-	}{
-		{
-			name:    "exception case",
-			isError: true,
-			input:   time.DateOnly,
-		},
-		{
-			name:     "valid RFC 3339",
-			isError:  false,
-			input:    "2025-02-09T23:30:00Z",
-			expected: time.Date(2025, time.February, 9, 23, 30, 0, 0, time.UTC),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			timestamp, err := RFC3339ToTime(tt.input)
-			if tt.isError {
-				assert.Error(t, err)
-			} else {
-				assert.Equal(t, tt.expected, timestamp)
 			}
 		})
 	}

--- a/util/time.go
+++ b/util/time.go
@@ -1,6 +1,9 @@
 package util
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 func TimeToDays(t time.Time) int32 {
 	// Get seconds since epoch
@@ -8,4 +11,27 @@ func TimeToDays(t time.Time) int32 {
 
 	// Convert to days (86400 seconds in a day)
 	return int32(seconds / 86400)
+}
+
+// DateStrToTime takes in a date string in the form 2024-01-25
+//
+// Parameter:
+//   - date: the date string to parse
+//
+// Returns a time.Time{} and nilable error
+func DateStrToTime(date string) (time.Time, error) {
+	dateParse, err := time.Parse(time.DateOnly, date)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("could not parse '%s': %w", date, err)
+	}
+	return dateParse, nil
+}
+
+// RFC3339ToTime converts a RFC 3339 timestamp string to time.Time
+func RFC3339ToTime(str string) (time.Time, error) {
+	timestamp, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("Could not convert RFC3339 string %s to time.Time: %w", str, err)
+	}
+	return timestamp, nil
 }

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -1,0 +1,81 @@
+//go:build unit
+
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDateStrToTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Time
+		isError  bool
+	}{
+		{
+			name:     "valid date",
+			input:    "2024-01-25",
+			expected: time.Date(2024, 1, 25, 0, 0, 0, 0, time.UTC),
+			isError:  false,
+		},
+		{
+			name:    "invalid date format",
+			input:   "01-25-2024",
+			isError: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			isError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := DateStrToTime(tt.input)
+			if tt.isError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRFC3339ToTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		isError  bool
+		input    string
+		expected time.Time
+	}{
+		{
+			name:    "exception case",
+			isError: true,
+			input:   time.DateOnly,
+		},
+		{
+			name:     "valid RFC 3339",
+			isError:  false,
+			input:    "2025-02-09T23:30:00Z",
+			expected: time.Date(2025, time.February, 9, 23, 30, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timestamp, err := RFC3339ToTime(tt.input)
+			if tt.isError {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tt.expected, timestamp)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Context
### Added
- Added `MatchupScraper` for baseball savant mlb
### Changed
- Moved `RFC3339ToTime` and `DateStrToTime` to time.go
- Documentation updates

### Example
```go
package main

import (
	"encoding/json"
	"fmt"
	"log"

	"github.com/lightning-dabbler/sportscrape"
	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb"
)

func main() {
	date := "2025-06-25"
	matchupscraper := baseballsavantmlb.NewMatchupScraper(
		baseballsavantmlb.MatchupScraperDate(date),
	)
	matchuprunner := sportscrape.NewMatchupRunner(
		sportscrape.MatchupRunnerScraper(matchupscraper),
	)
	matchups, err := matchuprunner.Run()
	if err != nil {
		panic(err)
	}
	// Output each statline as pretty json
	for _, matchup := range matchups {
		jsonBytes, err := json.MarshalIndent(matchup, "", "  ")
		if err != nil {
			log.Fatalf("Error marshaling to JSON: %v\n", err)
		}
		fmt.Println(string(jsonBytes))
	}
}

```
