### PR TITLE
Release/v0.12.0

### DIFF
--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -9,6 +9,7 @@ on:
       - 'dataprovider/**'
       - '.github/workflows/all-tests.yml'
       - '.github/actions/setup-go/actions.yml'
+      - '*.go'
 
   workflow_call:
     outputs:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,6 +10,7 @@ on:
       - 'dataprovider/**'
       - '.github/workflows/unit-tests.yml'
       - '.github/actions/setup-go/actions.yml'
+      - '*.go'
 
 jobs:
   unit-tests:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added `MatchupScraper` for baseball savant mlb (#84)
+### Changed
+- Moved `RFC3339ToTime` and `DateStrToTime` to time.go (#84)
+- Documentation updates (#84)
 
 ## [0.11.0] - 2025-07-02
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.12.0] - 2025-07-10
 ### Added
 - Added `MatchupScraper` for baseball savant mlb (#84)
 - Added `FieldingBoxScoreScraper`,`BattingBoxScoreScraper`, `PitchingBoxScoreScraper`, and `PlayByPlayScraper` for baseball savant mlb (#86)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added `MatchupScraper` for baseball savant mlb (#84)
+- Added `FieldingBoxScoreScraper`,`BattingBoxScoreScraper`, `PitchingBoxScoreScraper`, and `PlayByPlayScraper` for baseball savant mlb (#86)
 ### Changed
 - Moved `RFC3339ToTime` and `DateStrToTime` to time.go (#84)
 - Documentation updates (#84)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Moved `RFC3339ToTime` and `DateStrToTime` to time.go (#84)
 - Documentation updates (#84)
+- Deprecation warning on baseball reference feed (#87)
 
 ## [0.11.0] - 2025-07-02
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,23 +60,27 @@ func main() {
 
 ## Data providers
 
-| Source                           | League | Feed                  | Periods Available       | Chromium Dependency |	Source Content Type	| Point-in-time|
+| Source                           | League | Feed                  | Periods Available       | Data Model |	Deprecated	| Point-in-time|
 |----------------------------------|--------|------------------------|:----------------------:|:-------------------:|:---------------------:|:------------:|
-| https://basketball-reference.com | NBA    | Matchup                | Full                   |☑️|	text/html	|✅|
-| https://basketball-reference.com | NBA    | Basic box score stats  | H1, H2, Q1, Q2, Q3, Q4, Full |☑️|	text/html	|✅|
-| https://basketball-reference.com | NBA    | Advanced box score stats| Full                  |☑️|text/html|✅|
-| https://baseball-reference.com   | MLB    | Matchup                | Full                   |☑️|text/html|✅|
-| https://baseball-reference.com   | MLB    | Batting box score stats| Full                   |☑️|text/html|✅|
-| https://baseball-reference.com   | MLB    | Pitching box score stats| Full                  |☑️|text/html|✅|
-| https://www.foxsports.com		   | NBA	| Matchup				 | Live, Full			  | |application/json|✅|
-| https://www.foxsports.com		   | NBA	| Box score stats		 | Live, Full			  | |application/json|✅|
-| https://www.foxsports.com		   | MLB	| Matchup				 | Live, Full			  | |application/json|✅|
-| https://www.foxsports.com		   | MLB	| Batting Box score stats| Live, Full			  | |application/json|✅|
-| https://www.foxsports.com		   | MLB	| Pitching Box score stats| Live, Full			  | |application/json|✅|
-| https://www.foxsports.com		   | MLB	| Probable starting pitcher| Full			  | |application/json|✅|
-| https://www.foxsports.com		   | NCAAB	| Matchup				 | Live, Full			  | |application/json|✅|
-| https://www.foxsports.com		   | NFL	| Matchup				 | Live, Full			  | |application/json|✅|
-| https://baseballsavant.mlb.com		   | MLB	| Matchup				 | Live, Full			  | |application/json|✅|
+| https://basketball-reference.com | NBA    | Matchup                | Full                   |[model](dataprovider/basketballreferencenba/model/matchup.go)|		|✅|
+| https://basketball-reference.com | NBA    | Basic box score stats  | H1, H2, Q1, Q2, Q3, Q4, Full |[model](dataprovider/basketballreferencenba/model/basic_box_score_stats.go)|		|✅|
+| https://basketball-reference.com | NBA    | Advanced box score stats| Full                  |[model](dataprovider/basketballreferencenba/model/adv_box_score_stats.go)||✅|
+| https://baseball-reference.com   | MLB    | Matchup                | Full                   |[model](dataprovider/baseballreferencemlb/model/matchup.go)||✅|
+| https://baseball-reference.com   | MLB    | Batting box score stats| Full                   |[model](dataprovider/baseballreferencemlb/model/batting_box_score_stats.go)||✅|
+| https://baseball-reference.com   | MLB    | Pitching box score stats| Full                  |[model](dataprovider/baseballreferencemlb/model/pitching_box_score_stats.go)||✅|
+| https://www.foxsports.com		   | NBA	| Matchup				 | Live, Full			  | [model](dataprovider/foxsports/model/matchup.go)||✅|
+| https://www.foxsports.com		   | NBA	| Box score stats		 | Live, Full			  | [model](dataprovider/foxsports/model/nba_box_score_stats.go)||✅|
+| https://www.foxsports.com		   | MLB	| Matchup				 | Live, Full			  | [model](dataprovider/baseballreferencemlb/model/matchup.go)||✅|
+| https://www.foxsports.com		   | MLB	| Batting Box score stats| Live, Full			  | [model](dataprovider/foxsports/model/mlb_batting_box_score_stats.go)||✅|
+| https://www.foxsports.com		   | MLB	| Pitching Box score stats| Live, Full			  | [model](dataprovider/foxsports/model/mlb_pitching_box_score_stats.goo)||✅|
+| https://www.foxsports.com		   | MLB	| Probable starting pitcher| Full			  | [model](dataprovider/foxsports/model/mlb_probable_starting_pitcher.go)||✅|
+| https://www.foxsports.com		   | NCAAB	| Matchup				 | Live, Full			  | [model](dataprovider/baseballreferencemlb/model/matchup.go)||✅|
+| https://www.foxsports.com		   | NFL	| Matchup				 | Live, Full			  | [model](dataprovider/baseballreferencemlb/model/matchup.go)||✅|
+| https://baseballsavant.mlb.com		   | MLB	| Matchup				 | Live, Full			  |[model](dataprovider/baseballsavantmlb/model/matchup.go) ||✅|
+| https://baseballsavant.mlb.com		   | MLB	| Batting box score stats| Live, Full			  |[model](dataprovider/baseballsavantmlb/model/batting_box_score.go) ||✅|
+| https://baseballsavant.mlb.com		   | MLB	| Pitching box score stats | Live, Full			  |[model](dataprovider/baseballsavantmlb/model/pitching_box_score.go) ||✅|
+| https://baseballsavant.mlb.com		   | MLB	| Fielding box score stats | Live, Full			  |[model](dataprovider/baseballsavantmlb/model/fielding_box_score.go) ||✅|
+| https://baseballsavant.mlb.com		   | MLB	| Play by play | Live, Full			  |[model](dataprovider/baseballsavantmlb/model/play_by_play.go) ||✅|
 
 ## Supported Formats
 File formats the constructed data models support on export and import.

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ func main() {
 - [basketball-reference.com NBA scrape examples](dataprovider/basketballreferencenba/example_test.go)
 - [baseball-reference.com MLB scrape examples](dataprovider/baseballreferencemlb/example_test.go)
 - [foxsports.com scraping examples](dataprovider/foxsports/example_test.go)
+- [baseballsavant.mlb.com scraping examples](dataprovider/baseballsavantmlb/example_test.go)
 
 ## Data providers
 
@@ -75,6 +76,7 @@ func main() {
 | https://www.foxsports.com		   | MLB	| Probable starting pitcher| Full			  | |application/json|✅|
 | https://www.foxsports.com		   | NCAAB	| Matchup				 | Live, Full			  | |application/json|✅|
 | https://www.foxsports.com		   | NFL	| Matchup				 | Live, Full			  | |application/json|✅|
+| https://baseballsavant.mlb.com		   | MLB	| Matchup				 | Live, Full			  | |application/json|✅|
 
 ## Supported Formats
 File formats the constructed data models support on export and import.
@@ -88,7 +90,7 @@ File formats the constructed data models support on export and import.
 Go 1.24 or higher
 
 ### Testing
-This project is using [mockery](https://github.com/vektra/mockery) to mock interfaces.
+This project is using [mockery](https://github.com/vektra/mockery) v3.5.0 to mock interfaces.
 
 To run unit tests:
 ```console

--- a/catalog.go
+++ b/catalog.go
@@ -36,8 +36,12 @@ var (
 	BasketballReferenceNBAAdvBoxScore Feed     = Feed(string(BasketballReference) + " nba advanced box score")
 
 	// baseball savant
-	BaseballSavant           Provider = "baseball savant"
-	BaseballSavantMLBMatchup Feed     = Feed(string(BaseballSavant) + " mlb matchup")
+	BaseballSavant                    Provider = "baseball savant"
+	BaseballSavantMLBMatchup          Feed     = Feed(string(BaseballSavant) + " mlb matchup")
+	BaseballSavantMLBPitchingBoxScore Feed     = Feed(string(BaseballSavant) + " mlb pitching box score")
+	BaseballSavantMLBBattingBoxScore  Feed     = Feed(string(BaseballSavant) + " mlb batting box score")
+	BaseballSavantMLBFieldingBoxScore Feed     = Feed(string(BaseballSavant) + " mlb fielding box score")
+	BaseballSavantMLBPlayByPlay       Feed     = Feed(string(BaseballSavant) + " mlb play by play")
 
 	// testing
 	DummyProvider Provider = "dummy provider"

--- a/catalog.go
+++ b/catalog.go
@@ -1,6 +1,9 @@
 package sportscrape
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+)
 
 type Provider string
 type Feed string
@@ -49,6 +52,10 @@ var (
 )
 
 func (p Provider) Deprecated() bool {
+	switch p {
+	case BaseballReference:
+		log.Printf("Warning: %s provider will be deprecated as of v0.13.0\n", BaseballReference)
+	}
 	return false
 }
 

--- a/catalog.go
+++ b/catalog.go
@@ -35,6 +35,10 @@ var (
 	BasketballReferenceNBABoxScoreH2  Feed     = Feed(string(BasketballReference) + " nba h2 box score")
 	BasketballReferenceNBAAdvBoxScore Feed     = Feed(string(BasketballReference) + " nba advanced box score")
 
+	// baseball savant
+	BaseballSavant           Provider = "baseball savant"
+	BaseballSavantMLBMatchup Feed     = Feed(string(BaseballSavant) + " mlb matchup")
+
 	// testing
 	DummyProvider Provider = "dummy provider"
 	DummyFeed     Feed     = Feed(string(DummyProvider) + " dummy feed")

--- a/dataprovider/baseballreferencemlb/scraper_batting_box_score_stats_test.go
+++ b/dataprovider/baseballreferencemlb/scraper_batting_box_score_stats_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetBattingBoxScoreStats(t *testing.T) {
+func TestBattingBoxScoreScraper(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}

--- a/dataprovider/baseballreferencemlb/scraper_matchups.go
+++ b/dataprovider/baseballreferencemlb/scraper_matchups.go
@@ -91,7 +91,7 @@ func (ms *MatchupScraper) Scrape() sportscrape.MatchupOutput {
 	var matchups []interface{}
 	output := sportscrape.MatchupOutput{}
 	var skips int
-	timestamp, err := sportsreference.DateStrToTime(ms.Date)
+	timestamp, err := util.DateStrToTime(ms.Date)
 	if err != nil {
 		output.Error = err
 		return output

--- a/dataprovider/baseballreferencemlb/scraper_matchups_test.go
+++ b/dataprovider/baseballreferencemlb/scraper_matchups_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetMatchups(t *testing.T) {
+func TestMatchupScraper(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip("Skipping integration test")

--- a/dataprovider/baseballreferencemlb/scraper_pitching_box_score_stats_test.go
+++ b/dataprovider/baseballreferencemlb/scraper_pitching_box_score_stats_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetPitchingBoxScoreStats(t *testing.T) {
+func TestPitchingBoxScoreScraper(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}

--- a/dataprovider/baseballsavantmlb/example_test.go
+++ b/dataprovider/baseballsavantmlb/example_test.go
@@ -1,0 +1,33 @@
+package baseballsavantmlb_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb"
+)
+
+// Example for baseballsavantmlb.MatchupScraper
+func ExampleMatchupScraper() {
+	date := "2025-06-25"
+	matchupscraper := baseballsavantmlb.NewMatchupScraper(
+		baseballsavantmlb.MatchupScraperDate(date),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	if err != nil {
+		panic(err)
+	}
+	// Output each statline as pretty json
+	for _, matchup := range matchups {
+		jsonBytes, err := json.MarshalIndent(matchup, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}

--- a/dataprovider/baseballsavantmlb/example_test.go
+++ b/dataprovider/baseballsavantmlb/example_test.go
@@ -31,3 +31,146 @@ func ExampleMatchupScraper() {
 		fmt.Println(string(jsonBytes))
 	}
 }
+
+// Example for baseballsavantmlb.FieldingBoxScoreScraper
+func ExampleFieldingBoxScoreScraper() {
+	matchupscraper := baseballsavantmlb.NewMatchupScraper(
+		baseballsavantmlb.MatchupScraperDate("2024-10-30"),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	boxscorescraper := baseballsavantmlb.NewFieldingBoxScoreScraper()
+
+	boxscorerunner := sportscrape.NewEventDataRunner(
+		sportscrape.EventDataRunnerScraper(boxscorescraper),
+		sportscrape.EventDataRunnerConcurrency(1),
+	)
+
+	stats, err := boxscorerunner.Run(matchups...)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output each statline as pretty json
+	for _, statline := range stats {
+		jsonBytes, err := json.MarshalIndent(statline, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+
+}
+
+// Example for baseballsavantmlb.BattingBoxScoreScraper
+func ExampleBattingBoxScoreScraper() {
+	matchupscraper := baseballsavantmlb.NewMatchupScraper(
+		baseballsavantmlb.MatchupScraperDate("2024-10-30"),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	boxscorescraper := baseballsavantmlb.NewBattingBoxScoreScraper()
+
+	boxscorerunner := sportscrape.NewEventDataRunner(
+		sportscrape.EventDataRunnerScraper(boxscorescraper),
+		sportscrape.EventDataRunnerConcurrency(1),
+	)
+
+	stats, err := boxscorerunner.Run(matchups...)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output each statline as pretty json
+	for _, statline := range stats {
+		jsonBytes, err := json.MarshalIndent(statline, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+
+}
+
+// Example for baseballsavantmlb.PitchingBoxScoreScraper
+func ExamplePitchingBoxScoreScraper() {
+	matchupscraper := baseballsavantmlb.NewMatchupScraper(
+		baseballsavantmlb.MatchupScraperDate("2024-10-30"),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	boxscorescraper := baseballsavantmlb.NewPitchingBoxScoreScraper()
+
+	boxscorerunner := sportscrape.NewEventDataRunner(
+		sportscrape.EventDataRunnerScraper(boxscorescraper),
+		sportscrape.EventDataRunnerConcurrency(1),
+	)
+
+	stats, err := boxscorerunner.Run(matchups...)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output each statline as pretty json
+	for _, statline := range stats {
+		jsonBytes, err := json.MarshalIndent(statline, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}
+
+// Example for baseballsavantmlb.PlayByPlayScraper
+func ExamplePlayByPlayScraper() {
+	matchupscraper := baseballsavantmlb.NewMatchupScraper(
+		baseballsavantmlb.MatchupScraperDate("2024-10-30"),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	playbyplayscraper := baseballsavantmlb.NewPlayByPlayScraper()
+
+	playbyplayrunner := sportscrape.NewEventDataRunner(
+		sportscrape.EventDataRunnerScraper(playbyplayscraper),
+		sportscrape.EventDataRunnerConcurrency(1),
+	)
+
+	plays, err := playbyplayrunner.Run(matchups...)
+	if err != nil {
+		panic(err)
+	}
+
+	// Output each play as pretty json
+	for _, play := range plays {
+		jsonBytes, err := json.MarshalIndent(play, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+
+}

--- a/dataprovider/baseballsavantmlb/jsonresponse/event_data.go
+++ b/dataprovider/baseballsavantmlb/jsonresponse/event_data.go
@@ -1,0 +1,187 @@
+package jsonresponse
+
+// https://baseballsavant.mlb.com/gf?game_pk=777267
+
+type GameFeed struct {
+	AwayLineup        Lineup   `json:"away_lineup"`
+	HomeLineup        Lineup   `json:"home_lineup"`
+	AwayPitcherLineup Lineup   `json:"away_pitcher_lineup"`
+	HomePitcherLineup Lineup   `json:"home_pitcher_lineup"`
+	HomePitchers      *Plays   `json:"home_pitchers"`
+	HomeBatters       *Plays   `json:"home_batters"`
+	AwayBatters       *Plays   `json:"away_batters"`
+	AwayPitchers      *Plays   `json:"away_pitchers"`
+	BoxScore          BoxScore `json:"boxscore"`
+}
+type Lineup []int64
+type Plays map[string][]Play
+type Play struct {
+	PlayID   string `json:"play_id"`   // "7b71add6-fa6c-3411-958c-02e36b829678"
+	Inning   int32  `json:"inning"`    // 2
+	AtBatNum int32  `json:"ab_number"` // 12
+	Strikes  int32  `json:"strikes"`   // 1
+	Balls    int32  `json:"balls"`     // 0
+	Outs     int32  `json:"outs"`      // 2
+	// PreStrikes is the number of strikes before the current play
+	PreStrikes int32 `json:"pre_strikes"` // 1
+	// PreBalls is the number of balls before the current play
+	PreBalls int32 `json:"pre_balls"` // 0
+	BatterID int64 `json:"batter"`    // 572191
+	// BatterStand is the abbreviation of the side of the home plate the batter is standing
+	// R = the first-base side of the home plate, L = the third-base side of home plate
+	BatterStand  string `json:"stand"`        // "R"
+	BatterName   string `json:"batter_name"`  // "Michael A. Taylor"
+	PitcherID    int64  `json:"pitcher"`      // 477132
+	PitcherThrow string `json:"p_throws"`     // "L"
+	PitcherName  string `json:"pitcher_name"` // "Clayton Kershaw"
+	// Result is the terminal outcome of the batter
+	Result *string `json:"result"` //"Flyout"
+	// ResultDescription extrapolates on Result
+	ResultDescription *string `json:"des"`        // "Michael A. Taylor flies out to left fielder Michael Conforto."
+	PitchType         string  `json:"pitch_type"` // "SL"
+	PitchName         string  `json:"pitch_name"` // "Slider"
+	// CallName is the call on the play
+	CallName                       string  `json:"call_name"`                        // "Strike"
+	CallDescription                string  `json:"description"`                      // "Swinging Strike"
+	IsStrikeSwinging               bool    `json:"is_strike_swinging"`               // true
+	PitchStartSpeed                float32 `json:"start_speed"`                      // 83.4
+	PitchEndSpeed                  float32 `json:"end_speed"`                        // 77.4
+	PitchNumber                    int32   `json:"pitch_number"`                     // 2
+	PitcherTotalPitches            int32   `json:"player_total_pitches"`             // 34
+	PitcherTotalPitchesByPitchType int32   `json:"player_total_pitches_pitch_types"` // 16
+	GameTotalPitches               int32   `json:"game_total_pitches"`               // 61
+	HitSpeed                       *string `json:"hit_speed"`                        // "94.3"
+	HitDistance                    *string `json:"hit_distance"`                     // "336"
+}
+
+type BoxScore struct {
+	Teams struct {
+		Away BoxScoreTeam `json:"away"`
+		Home BoxScoreTeam `json:"home"`
+	} `json:"teams"`
+}
+
+type BoxScoreTeam struct {
+	Players map[string]Player `json:"players"`
+}
+
+type Player struct {
+	Person struct {
+		ID   int64  `json:"id"`       // 676508
+		Name string `json:"fullName"` // "Ben Casparius"
+	} `json:"person"`
+	Position struct {
+		Name         string `json:"name"`         // "Pitcher"
+		Type         string `json:"type"`         // "Pitcher"
+		Abbreviation string `json:"abbreviation"` // "P"
+	} `json:"position"`
+	Stats struct {
+		Batting  BoxScorePlayerBatting  `json:"batting"`
+		Pitching BoxScorePlayerPitching `json:"pitching"`
+		Fielding BoxScorePlayerFielding `json:"fielding"`
+	} `json:"stats"`
+}
+
+type BoxScorePlayerBatting struct {
+	Summary              string `json:"summary"`              // "2-3 | HR, BB, HBP"
+	GamesPlayed          int32  `json:"gamesPlayed"`          // 1
+	FlyOuts              int32  `json:"flyOuts"`              // 0
+	GroundOuts           int32  `json:"groundOuts"`           // 1
+	AirOuts              int32  `json:"airOuts"`              // 0
+	Runs                 int32  `json:"runs"`                 // 1
+	Doubles              int32  `json:"doubles"`              // 0
+	Triples              int32  `json:"triples"`              // 0
+	HomeRuns             int32  `json:"homeRuns"`             // 1
+	StrikeOuts           int32  `json:"strikeOuts"`           // 0
+	BaseOnBalls          int32  `json:"baseOnBalls"`          // 1
+	IntentionalWalks     int32  `json:"intentionalWalks"`     // 0
+	Hits                 int32  `json:"hits"`                 // 2
+	HitByPitch           int32  `json:"hitByPitch"`           // 1
+	AtBats               int32  `json:"atBats"`               // 3
+	CaughtStealing       int32  `json:"caughtStealing"`       // 0
+	StolenBases          int32  `json:"stolenBases"`          // 0
+	StolenBasePercentage string `json:"stolenBasePercentage"` // ".---"
+	GroundIntoDoublePlay int32  `json:"groundIntoDoublePlay"` // 0
+	GroundIntoTriplePlay int32  `json:"groundIntoTriplePlay"` // 0
+	PlateAppearances     int32  `json:"plateAppearances"`     // 5
+	TotalBases           int32  `json:"totalBases"`           // 5
+	RBI                  int32  `json:"rbi"`                  // 1
+	LeftOnBase           int32  `json:"leftOnBase"`           // 2
+	SacBunts             int32  `json:"sacBunts"`             // 0
+	SacFlies             int32  `json:"sacFlies"`             // 0
+	CatchersInterference int32  `json:"catchersInterference"` // 0
+	Pickoffs             int32  `json:"pickoffs"`             // 0
+	AtBatsPerHomeRun     string `json:"atBatsPerHomeRun"`     // "3.00"
+	PopOuts              int32  `json:"popOuts"`              // 0
+	LineOuts             int32  `json:"lineOuts"`             // 0
+}
+
+type BoxScorePlayerPitching struct {
+	Summary                string `json:"summary"`                // "2.0 IP, 0 ER, 0 K, 0 BB"
+	GamesPlayed            int32  `json:"gamesPlayed"`            // 1
+	GamesStarted           int32  `json:"gamesStarted"`           // 0
+	FlyOuts                int32  `json:"flyOuts"`                // 2
+	GroundOuts             int32  `json:"groundOuts"`             // 2
+	AirOuts                int32  `json:"airOuts"`                // 3
+	Runs                   int32  `json:"runs"`                   // 0
+	Doubles                int32  `json:"doubles"`                // 0
+	Triples                int32  `json:"triples"`                // 0
+	HomeRuns               int32  `json:"homeRuns"`               // 0
+	StrikeOuts             int32  `json:"strikeOuts"`             // 0
+	BaseOnBalls            int32  `json:"baseOnBalls"`            // 0
+	IntentionalWalks       int32  `json:"intentionalWalks"`       // 0
+	Hits                   int32  `json:"hits"`                   // 0
+	HitByPitch             int32  `json:"hitByPitch"`             // 1
+	AtBats                 int32  `json:"atBats"`                 // 5
+	CaughtStealing         int32  `json:"caughtStealing"`         // 0
+	StolenBases            int32  `json:"stolenBases"`            // 0
+	StolenBasePercentage   string `json:"stolenBasePercentage"`   // ".---"
+	NumberOfPitches        int32  `json:"numberOfPitches"`        // 26
+	InningsPitched         string `json:"inningsPitched"`         // "2.0"
+	Wins                   int32  `json:"wins"`                   // 0
+	Losses                 int32  `json:"losses"`                 // 0
+	Saves                  int32  `json:"saves"`                  // 0
+	SaveOpportunities      int32  `json:"saveOpportunities"`      // 0
+	Holds                  int32  `json:"holds"`                  // 0
+	BlownSaves             int32  `json:"blownSaves"`             // 0
+	EarnedRuns             int32  `json:"earnedRuns"`             // 0
+	BattersFaced           int32  `json:"battersFaced"`           // 6
+	Outs                   int32  `json:"outs"`                   // 6
+	GamesPitched           int32  `json:"gamesPitched"`           // 1
+	CompleteGames          int32  `json:"completeGames"`          // 0
+	Shutouts               int32  `json:"shutouts"`               // 0
+	PitchesThrown          int32  `json:"pitchesThrown"`          // 26
+	Balls                  int32  `json:"balls"`                  // 10
+	Strikes                int32  `json:"strikes"`                // 16
+	StrikePercentage       string `json:"strikePercentage"`       // ".620"
+	HitBatsmen             int32  `json:"hitBatsmen"`             // 1
+	Balks                  int32  `json:"balks"`                  // 0
+	WildPitches            int32  `json:"wildPitches"`            // 0
+	Pickoffs               int32  `json:"pickoffs"`               // 0
+	RBI                    int32  `json:"rbi"`                    // 0
+	GamesFinished          int32  `json:"gamesFinished"`          // 1
+	RunsScoredPer9         string `json:"runsScoredPer9"`         // "0.00"
+	HomeRunsPer9           string `json:"homeRunsPer9"`           // "0.00"
+	InheritedRunners       int32  `json:"inheritedRunners"`       // 0
+	InheritedRunnersScored int32  `json:"inheritedRunnersScored"` // 0
+	CatchersInterference   int32  `json:"catchersInterference"`   // 0
+	SacBunts               int32  `json:"sacBunts"`               // 0
+	SacFlies               int32  `json:"sacFlies"`               // 0
+	PassedBall             int32  `json:"passedBall"`             // 0
+	PopOuts                int32  `json:"popOuts"`                // 1
+	LineOuts               int32  `json:"lineOuts"`               // 0
+}
+
+type BoxScorePlayerFielding struct {
+	GamesStarted         int32  `json:"gamesStarted"`         // 1
+	CaughtStealing       int32  `json:"caughtStealing"`       // 1
+	StolenBases          int32  `json:"stolenBases"`          // 1
+	StolenBasePercentage string `json:"stolenBasePercentage"` // ".500"
+	Assists              int32  `json:"assists"`              // 1
+	PutOuts              int32  `json:"putOuts"`              // 7
+	Errors               int32  `json:"errors"`               // 0
+	Chances              int32  `json:"chances"`              // 8
+	Fielding             string `json:"fielding"`             // ".000"
+	PassedBall           int32  `json:"passedBall"`           // 0
+	Pickoffs             int32  `json:"pickoffs"`             // 0
+}

--- a/dataprovider/baseballsavantmlb/jsonresponse/matchup.go
+++ b/dataprovider/baseballsavantmlb/jsonresponse/matchup.go
@@ -1,0 +1,49 @@
+package jsonresponse
+
+// https://baseballsavant.mlb.com/schedule?date=2025-6-24
+
+type Matchups struct {
+	Schedule struct {
+		Dates []Date `json:"dates"`
+	} `json:"schedule"`
+}
+
+type Date struct {
+	TotalGames int32  `json:"totalGames"`
+	Games      []Game `json:"games"`
+}
+
+type Game struct {
+	EventID   int64  `json:"gamePk"`   // "gamePk": 777386
+	EventTime string `json:"gameDate"` // "gameDate": "2025-06-24T18:40:00-04:00"
+	Status    struct {
+		DetailedState string `json:"detailedState"` // "detailedState": "Final"
+	} `json:"status"`
+	Season            string `json:"season"`            // "season": "2025"
+	GameType          string `json:"gameType"`          // "gameType": "R"
+	SeriesDescription string `json:"seriesDescription"` // "seriesDescription": "Regular Season"
+	GamesInSeries     int32  `json:"gamesInSeries"`     // "gamesInSeries": 3
+	SeriesGameNumber  int32  `json:"seriesGameNumber"`  // "seriesGameNumber": 1
+	Teams             struct {
+		Away Team `json:"away"`
+		Home Team `json:"home"`
+	} `json:"teams"`
+}
+
+type Team struct {
+	LeagueRecord struct {
+		Wins   int32 `json:"wins"`   // "wins": 44
+		Losses int32 `json:"losses"` // "losses": 24
+	} `json:"leagueRecord"`
+	Score    *int32 `json:"score"`    // "score": 4
+	IsWinner *bool  `json:"isWinner"` // "isWinner": false,
+	Team     struct {
+		ID           int64  `json:"id"`           // "id": 116
+		Name         string `json:"name"`         // "name": "Detroit Tigers"
+		Abbreviation string `json:"abbreviation"` // "abbreviation": "NYM"
+	} `json:"team"`
+	ProbablePitcher *struct {
+		ID   int64  `json:"id"`       // "id": 694973,
+		Name string `json:"fullName"` // "fullName": "Paul Skenes"
+	} `json:"probablePitcher"`
+}

--- a/dataprovider/baseballsavantmlb/model/batting_box_score.go
+++ b/dataprovider/baseballsavantmlb/model/batting_box_score.go
@@ -1,0 +1,86 @@
+package model
+
+import "time"
+
+// BattingBoxScore represents the data model for MLB batting box score stats scraped from baseballsavant.mlb.com
+type BattingBoxScore struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// PullTimestampParquet is the fetch timestamp (in milliseconds)
+	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// EventID is a unique ID that maps to the matchup e.g. 86833
+	EventID int64 `json:"event_id" parquet:"name=event_id, type=INT64"`
+	// EventTime is the timestamp associated with the matchup
+	EventTime time.Time `json:"event_time"`
+	// EventTimeParquet is the timestamp associated with the matchup (in milliseconds)
+	EventTimeParquet int64 `json:"-" parquet:"name=event_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// TeamID
+	TeamID int64 `json:"team_id" parquet:"name=team_id, type=INT64"`
+	// Team is the player's team name
+	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// Opponent is the opposing team name
+	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// OpponentID
+	OpponentID int64 `json:"opponent_id" parquet:"name=opponent_id, type=INT64"`
+	// PlayerID
+	PlayerID int64 `json:"player_id" parquet:"name=player_id, type=INT64"`
+	// Player is the pitcher's name
+	Player   string `json:"player" parquet:"name=player, type=BYTE_ARRAY, convertedtype=UTF8"`
+	Position string `json:"position" parquet:"name=position, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// FlyOuts - https://www.mlb.com/glossary/standard-stats/flyout
+	FlyOuts int32 `json:"fly_outs" parquet:"name=fly_outs, type=INT32"`
+	// GroundOuts - https://www.mlb.com/glossary/standard-stats/groundout
+	GroundOuts int32 `json:"ground_outs" parquet:"name=ground_outs, type=INT32"`
+	// AirOuts - refers to a batted ball that is hit in the air, either a fly ball or a line drive, and is caught by a fielder for an out
+	AirOuts int32 `json:"air_outs" parquet:"name=air_outs, type=INT32"`
+	// Runs - https://www.mlb.com/glossary/standard-stats/run
+	Runs int32 `json:"runs" parquet:"name=runs, type=INT32"`
+	// Doubles - https://www.mlb.com/glossary/standard-stats/double
+	Doubles int32 `json:"doubles" parquet:"name=doubles, type=INT32"`
+	// Triples - https://www.mlb.com/glossary/standard-stats/triple
+	Triples int32 `json:"triples" parquet:"name=triples, type=INT32"`
+	// HomeRuns - https://www.mlb.com/glossary/standard-stats/home-run
+	HomeRuns int32 `json:"home_runs" parquet:"name=home_runs, type=INT32"`
+	// Strikeouts - https://www.mlb.com/glossary/standard-stats/strikeout
+	Strikeouts int32 `json:"strikeouts" parquet:"name=strikeouts, type=INT32"`
+	// Walks - https://www.mlb.com/glossary/standard-stats/walk
+	Walks int32 `json:"walks" parquet:"name=walks, type=INT32"`
+	// IntentionalWalks - https://www.mlb.com/glossary/standard-stats/intentional-walk
+	IntentionalWalks int32 `json:"intentional_walks" parquet:"name=intentional_walks, type=INT32"`
+	// Hits - https://www.mlb.com/glossary/standard-stats/hit
+	Hits int32 `json:"hits" parquet:"name=hits, type=INT32"`
+	// HitByPitch - https://www.mlb.com/glossary/standard-stats/hit-by-pitch
+	HitByPitch int32 `json:"hit_by_pitch" parquet:"name=hit_by_pitch, type=INT32"`
+	// AtBats - https://www.mlb.com/glossary/standard-stats/at-bat
+	AtBats int32 `json:"at_bats" parquet:"name=at_bats, type=INT32"`
+	// CaughtStealing - https://www.mlb.com/glossary/standard-stats/caught-stealing
+	CaughtStealing int32 `json:"caught_stealing" parquet:"name=caught_stealing, type=INT32"`
+	// StolenBases - https://www.mlb.com/glossary/standard-stats/stolen-base
+	StolenBases int32 `json:"stolen_bases" parquet:"name=stolen_bases, type=INT32"`
+	// GroundIntoDoublePlay - https://www.mlb.com/glossary/standard-stats/ground-into-double-play
+	GroundIntoDoublePlay int32 `json:"ground_into_double_play" parquet:"name=ground_into_double_play, type=INT32"`
+	// GroundIntoTriplePlay - https://www.mlb.com/glossary/standard-stats/triple-play
+	GroundIntoTriplePlay int32 `json:"ground_into_triple_play" parquet:"name=ground_into_triple_play, type=INT32"`
+	// PlateAppearances - https://www.mlb.com/glossary/standard-stats/plate-appearance
+	PlateAppearances int32 `json:"plate_appearances" parquet:"name=plate_appearances, type=INT32"`
+	// TotalBases - https://www.mlb.com/glossary/standard-stats/total-bases
+	TotalBases int32 `json:"total_bases" parquet:"name=total_bases, type=INT32"`
+	// RBI - https://www.mlb.com/glossary/standard-stats/runs-batted-in
+	RBI int32 `json:"rbi" parquet:"name=rbi, type=INT32"`
+	// LeftOnBase - https://www.mlb.com/glossary/standard-stats/left-on-base
+	LeftOnBase int32 `json:"left_on_base" parquet:"name=left_on_base, type=INT32"`
+	// SacBunts - https://www.mlb.com/glossary/standard-stats/sacrifice-bunt
+	SacBunts int32 `json:"sac_bunts" parquet:"name=sac_bunts, type=INT32"`
+	// SacFlies - https://www.mlb.com/glossary/standard-stats/sacrifice-fly
+	SacFlies int32 `json:"sac_flies" parquet:"name=sac_flies, type=INT32"`
+	// CatchersInterference - https://www.mlb.com/glossary/rules/catcher-interference
+	CatchersInterference int32 `json:"catchers_interference" parquet:"name=catchers_interference, type=INT32"`
+	// Pickoffs - https://www.mlb.com/glossary/standard-stats/pickoff
+	Pickoffs int32 `json:"pickoffs" parquet:"name=pickoffs, type=INT32"`
+	// AtBatsPerHomeRun - https://en.wikipedia.org/wiki/At_bats_per_home_run
+	AtBatsPerHomeRun float32 `json:"at_bats_per_home_run" parquet:"name=at_bats_per_home_run, type=FLOAT"`
+	// PopOuts - a pop fly that is caught for an out
+	PopOuts int32 `json:"pop_outs" parquet:"name=pop_outs, type=INT32"`
+	// LineOuts - a batter hits a line drive and a fielder catches the ball before it hits the ground
+	LineOuts int32 `json:"line_outs" parquet:"name=line_outs, type=INT32"`
+}

--- a/dataprovider/baseballsavantmlb/model/fielding_box_score.go
+++ b/dataprovider/baseballsavantmlb/model/fielding_box_score.go
@@ -1,0 +1,46 @@
+package model
+
+import "time"
+
+// FieldingBoxScore represents the data model for MLB fielding box score stats scraped from baseballsavant.mlb.com
+type FieldingBoxScore struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// PullTimestampParquet is the fetch timestamp (in milliseconds)
+	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// EventID is a unique ID that maps to the matchup e.g. 86833
+	EventID int64 `json:"event_id" parquet:"name=event_id, type=INT64"`
+	// EventTime is the timestamp associated with the matchup
+	EventTime time.Time `json:"event_time"`
+	// EventTimeParquet is the timestamp associated with the matchup (in milliseconds)
+	EventTimeParquet int64 `json:"-" parquet:"name=event_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// TeamID
+	TeamID int64 `json:"team_id" parquet:"name=team_id, type=INT64"`
+	// Team is the player's team name
+	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// Opponent is the opposing team name
+	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// OpponentID
+	OpponentID int64 `json:"opponent_id" parquet:"name=opponent_id, type=INT64"`
+	// PlayerID
+	PlayerID int64 `json:"player_id" parquet:"name=player_id, type=INT64"`
+	// Player is the pitcher's name
+	Player   string `json:"player" parquet:"name=player, type=BYTE_ARRAY, convertedtype=UTF8"`
+	Position string `json:"position" parquet:"name=position, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// CaughtStealing - https://www.mlb.com/glossary/standard-stats/caught-stealing
+	CaughtStealing int32 `json:"caught_stealing" parquet:"name=caught_stealing, type=INT32"`
+	// StolenBases - https://www.mlb.com/glossary/standard-stats/stolen-base
+	StolenBases int32 `json:"stolen_bases" parquet:"name=stolen_bases, type=INT32"`
+	// Assists - https://www.mlb.com/glossary/standard-stats/assist
+	Assists int32 `json:"assists" parquet:"name=assists, type=INT32"`
+	// Putouts - https://www.mlb.com/glossary/standard-stats/putout
+	Putouts int32 `json:"putouts" parquet:"name=putouts, type=INT32"`
+	// Errors - https://www.mlb.com/glossary/standard-stats/error
+	Errors int32 `json:"errors" parquet:"name=errors, type=INT32"`
+	// Chances - https://www.mlb.com/glossary/standard-stats/total-chances
+	Chances int32 `json:"chances" parquet:"name=chances, type=INT32"`
+	// PassedBall - https://www.mlb.com/glossary/standard-stats/passed-ball
+	PassedBall int32 `json:"passed_ball" parquet:"name=passed_ball, type=INT32"`
+	// Pickoffs - https://www.mlb.com/glossary/standard-stats/pickoff
+	Pickoffs int32 `json:"pickoffs" parquet:"name=pickoffs, type=INT32"`
+}

--- a/dataprovider/baseballsavantmlb/model/matchup.go
+++ b/dataprovider/baseballsavantmlb/model/matchup.go
@@ -1,0 +1,63 @@
+package model
+
+import "time"
+
+// Matchup represents the data model for MLB matchups scraped from baseballsavant.mlb.com
+type Matchup struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// PullTimestampParquet is the fetch timestamp (in milliseconds)
+	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// EventID is a unique ID that maps to the matchup e.g. 86833
+	EventID int64 `json:"event_id" parquet:"name=event_id, type=INT64"`
+	// EventTime is the timestamp associated with the matchup
+	EventTime time.Time `json:"event_time"`
+	// EventTimeParquet is the timestamp associated with the matchup (in milliseconds)
+	EventTimeParquet int64 `json:"-" parquet:"name=event_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// Status is the string representation of the event status e.g. Final
+	Status string `json:"status" parquet:"name=status, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// HomeTeamID is the home team's ID
+	HomeTeamID int64 `json:"home_team_id" parquet:"name=home_team_id, type=INT64"`
+	// HomeTeamAbbreviation is the abbreviation of the home team's name e.g. DET
+	HomeTeamAbbreviation string `json:"home_team_abbreviation" parquet:"name=home_team_abbreviation, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// HomeTeamName is the home team's full name e.g. Detroit Tigers
+	HomeTeamName string `json:"home_team_name" parquet:"name=home_team_name_full, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// HomeRecord is the home team's number of wins
+	HomeWins int32 `json:"home_wins" parquet:"name=home_wins, type=INT32"`
+	// HomeLosses is the home team's number of losses
+	HomeLosses int32 `json:"home_losses" parquet:"name=home_losses, type=INT32"`
+	// HomeScore is the home team's score at time of request
+	HomeScore *int32 `json:"home_score" parquet:"name=home_score, type=INT32"`
+	// HomeStartingPitcherID is the player id for the home team's starting pitcher (nillable because it may not be yet announced when fetching a scheduled event)
+	HomeStartingPitcherID *int64 `json:"home_starting_pitcher_id" parquet:"name=home_starting_pitcher_id, type=INT64"`
+	// HomeStartingPitcher the name of the home team's starting pitcher
+	HomeStartingPitcher *string `json:"home_starting_pitcher" parquet:"name=home_starting_pitcher, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// AwayTeamID is the away team's ID e.g. 8
+	AwayTeamID int64 `json:"away_team_id" parquet:"name=away_team_id, type=INT64"`
+	// AwayTeamAbbreviation is the abbreviation of the away team's name e.g. LAA
+	AwayTeamAbbreviation string `json:"away_team_abbreviation" parquet:"name=away_team_abbreviation, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// AwayTeamName is the away team's full name
+	AwayTeamName string `json:"away_team_name" parquet:"name=away_team_name_full, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// AwayRecord is the away team's number of wins
+	AwayWins int32 `json:"away_wins" parquet:"name=away_wins, type=INT32"`
+	// AwayLosses is the away team's number of losses
+	AwayLosses int32 `json:"away_losses" parquet:"name=away_losses, type=INT32"`
+	// AwayScore is the away team's score at time of request
+	AwayScore *int32 `json:"away_score" parquet:"name=away_score, type=INT32"`
+	// AwayStartingPitcherID is the player id for the away team's starting pitcher (nillable because it may not be yet announced when fetching a scheduled event)
+	AwayStartingPitcherID *int64 `json:"away_starting_pitcher_id" parquet:"name=away_starting_pitcher_id, type=INT64"`
+	// AwayStartingPitcher the name of the away team's starting pitcher
+	AwayStartingPitcher *string `json:"away_starting_pitcher" parquet:"name=away_starting_pitcher, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// Loser is an optional team id associated with the loser. Optional because some games could be live a loser will not be determined until the matchup is complete.
+	Loser *int64 `json:"loser" parquet:"name=loser, type=INT64"`
+	// GameType is an abbreviation that indicates the type of event taking place (e.g. "R", "S", "W", etc.)
+	GameType string `json:"game_type" parquet:"name=game_type, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// SeriesDescription acts as supplemental information for GameType (e.g. "Regular Season", "Spring Training", "World Series", etc.)
+	SeriesDescription string `json:"series_description" parquet:"name=series_description, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// GamesInSeries is the number of games being played in this series of matchup
+	GamesInSeries int32 `json:"games_in_series" parquet:"name=games_in_series, type=INT32"`
+	// SeriesGameNumber is the series game number of the event
+	SeriesGameNumber int32 `json:"series_game_number" parquet:"name=series_game_number, type=INT32"`
+	// Season - e.g. 2025
+	Season int32 `json:"season" parquet:"name=season, type=INT32"`
+}

--- a/dataprovider/baseballsavantmlb/model/pitching_box_score.go
+++ b/dataprovider/baseballsavantmlb/model/pitching_box_score.go
@@ -1,0 +1,105 @@
+package model
+
+import "time"
+
+// PitchingBoxScore represents the data model for MLB pitching box score stats scraped from baseballsavant.mlb.com
+type PitchingBoxScore struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// PullTimestampParquet is the fetch timestamp (in milliseconds)
+	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// EventID is a unique ID that maps to the matchup e.g. 86833
+	EventID int64 `json:"event_id" parquet:"name=event_id, type=INT64"`
+	// EventTime is the timestamp associated with the matchup
+	EventTime time.Time `json:"event_time"`
+	// EventTimeParquet is the timestamp associated with the matchup (in milliseconds)
+	EventTimeParquet int64 `json:"-" parquet:"name=event_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// TeamID
+	TeamID int64 `json:"team_id" parquet:"name=team_id, type=INT64"`
+	// Team is the player's team name
+	Team string `json:"team" parquet:"name=team, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// Opponent is the opposing team name
+	Opponent string `json:"opponent" parquet:"name=opponent, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// OpponentID
+	OpponentID int64 `json:"opponent_id" parquet:"name=opponent_id, type=INT64"`
+	// PlayerID
+	PlayerID int64 `json:"player_id" parquet:"name=player_id, type=INT64"`
+	// Player is the pitcher's name
+	Player   string `json:"player" parquet:"name=player, type=BYTE_ARRAY, convertedtype=UTF8"`
+	Position string `json:"position" parquet:"name=position, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// FlyOuts - https://www.mlb.com/glossary/standard-stats/flyout
+	FlyOuts int32 `json:"fly_outs" parquet:"name=fly_outs, type=INT32"`
+	// GroundOuts - https://www.mlb.com/glossary/standard-stats/groundout
+	GroundOuts int32 `json:"ground_outs" parquet:"name=ground_outs, type=INT32"`
+	// AirOuts - refers to a batted ball that is hit in the air, either a fly ball or a line drive, and is caught by a fielder for an out
+	AirOuts int32 `json:"air_outs" parquet:"name=air_outs, type=INT32"`
+	// Runs - https://www.mlb.com/glossary/standard-stats/run
+	Runs int32 `json:"runs" parquet:"name=runs, type=INT32"`
+	// Doubles - https://www.mlb.com/glossary/standard-stats/double
+	Doubles int32 `json:"doubles" parquet:"name=doubles, type=INT32"`
+	// Triples - https://www.mlb.com/glossary/standard-stats/triple
+	Triples int32 `json:"triples" parquet:"name=triples, type=INT32"`
+	// HomeRuns - https://www.mlb.com/glossary/standard-stats/home-run
+	HomeRuns int32 `json:"home_runs" parquet:"name=home_runs, type=INT32"`
+	// Strikeouts - https://www.mlb.com/glossary/standard-stats/strikeout
+	Strikeouts int32 `json:"strikeouts" parquet:"name=strikeouts, type=INT32"`
+	// Walks - https://www.mlb.com/glossary/standard-stats/walk
+	Walks int32 `json:"walks" parquet:"name=walks, type=INT32"`
+	// IntentionalWalks - https://www.mlb.com/glossary/standard-stats/intentional-walk
+	IntentionalWalks int32 `json:"intentional_walks" parquet:"name=intentional_walks, type=INT32"`
+	// Hits - https://www.mlb.com/glossary/standard-stats/hit
+	Hits int32 `json:"hits" parquet:"name=hits, type=INT32"`
+	// HitByPitch - https://www.mlb.com/glossary/standard-stats/hit-by-pitch
+	HitByPitch int32 `json:"hit_by_pitch" parquet:"name=hit_by_pitch, type=INT32"`
+	// AtBats - https://www.mlb.com/glossary/standard-stats/at-bat
+	AtBats int32 `json:"at_bats" parquet:"name=at_bats, type=INT32"`
+	// CaughtStealing - https://www.mlb.com/glossary/standard-stats/caught-stealing
+	CaughtStealing int32 `json:"caught_stealing" parquet:"name=caught_stealing, type=INT32"`
+	// StolenBases - https://www.mlb.com/glossary/standard-stats/stolen-base
+	StolenBases int32 `json:"stolen_bases" parquet:"name=stolen_bases, type=INT32"`
+	// NumberOfPitches https://www.mlb.com/glossary/standard-stats/number-of-pitches
+	NumberOfPitches int32 `json:"number_of_pitches" parquet:"name=number_of_pitches, type=INT32"`
+	// InningsPitched - https://www.mlb.com/glossary/standard-stats/innings-pitched
+	InningsPitched float32 `json:"innings_pitched" parquet:"name=innings_pitched, type=FLOAT"`
+	Wins           int32   `json:"wins" parquet:"name=wins, type=INT32"`
+	Losses         int32   `json:"losses" parquet:"name=losses, type=INT32"`
+	// Saves - https://www.mlb.com/glossary/standard-stats/save
+	Saves int32 `json:"saves" parquet:"name=saves, type=INT32"`
+	// BlownSaves - https://www.mlb.com/glossary/standard-stats/blown-save
+	BlownSaves int32 `json:"blown_saves" parquet:"name=blown_saves, type=INT32"`
+	// EarnedRuns - https://www.mlb.com/glossary/standard-stats/earned-run
+	EarnedRuns int32 `json:"earned_runs" parquet:"name=earned_runs, type=INT32"`
+	// BattersFaced - https://www.mlb.com/glossary/standard-stats/batters-faced
+	BattersFaced int32 `json:"batters_faced" parquet:"name=batters_faced, type=INT32"`
+	// Outs - https://www.mlb.com/glossary/standard-stats/out
+	Outs int32 `json:"outs" parquet:"name=outs, type=INT32"`
+	// Shutouts - https://www.mlb.com/glossary/standard-stats/shutout
+	Shutouts int32 `json:"shutouts" parquet:"name=shutouts, type=INT32"`
+	// Balls - pitches out of the strike zone
+	Balls int32 `json:"balls" parquet:"name=balls, type=INT32"`
+	// Strikes - https://en.wikipedia.org/wiki/Glossary_of_baseball_terms#strike
+	Strikes int32 `json:"strikes" parquet:"name=strikes, type=INT32"`
+	// Balk - https://www.mlb.com/glossary/standard-stats/balk
+	Balks int32 `json:"balks" parquet:"name=balks, type=INT32"`
+	// WildPitches - https://www.mlb.com/glossary/standard-stats/wild-pitch
+	WildPitches int32 `json:"wild_pitches" parquet:"name=wild_pitches, type=INT32"`
+	// Pickoffs - https://www.mlb.com/glossary/standard-stats/pickoff
+	Pickoffs int32 `json:"pickoffs" parquet:"name=pickoffs, type=INT32"`
+	// RBI - https://www.mlb.com/glossary/standard-stats/runs-batted-in
+	RBI int32 `json:"rbi" parquet:"name=rbi, type=INT32"`
+	// InheritedRunners - https://www.mlb.com/glossary/standard-stats/inherited-runner
+	InheritedRunners       int32 `json:"inherited_runners" parquet:"name=inherited_runners, type=INT32"`
+	InheritedRunnersScored int32 `json:"inherited_runners_scored" parquet:"name=inherited_runners_scored, type=INT32"`
+	// CatchersInterference - https://www.mlb.com/glossary/rules/catcher-interference
+	CatchersInterference int32 `json:"catchers_interference" parquet:"name=catchers_interference, type=INT32"`
+	// SacBunts - https://www.mlb.com/glossary/standard-stats/sacrifice-bunt
+	SacBunts int32 `json:"sac_bunts" parquet:"name=sac_bunts, type=INT32"`
+	// SacFlies - https://www.mlb.com/glossary/standard-stats/sacrifice-fly
+	SacFlies int32 `json:"sac_flies" parquet:"name=sac_flies, type=INT32"`
+	// PassedBall -https://www.mlb.com/glossary/standard-stats/passed-ball
+	PassedBall int32 `json:"passed_ball" parquet:"name=passed_ball, type=INT32"`
+	// PopOuts - a pop fly that is caught for an out
+	PopOuts int32 `json:"pop_outs" parquet:"name=pop_outs, type=INT32"`
+	// LineOuts - a batter hits a line drive and a fielder catches the ball before it hits the ground
+	LineOuts int32 `json:"line_outs" parquet:"name=line_outs, type=INT32"`
+}

--- a/dataprovider/baseballsavantmlb/model/play_by_play.go
+++ b/dataprovider/baseballsavantmlb/model/play_by_play.go
@@ -1,0 +1,76 @@
+package model
+
+import "time"
+
+// PlayByPlay represents the data model for MLB event play by play scraped from baseballsavant.mlb.com
+type PlayByPlay struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// PullTimestampParquet is the fetch timestamp (in milliseconds)
+	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// EventID is a unique ID that maps to the matchup e.g. 86833
+	EventID int64 `json:"event_id" parquet:"name=event_id, type=INT64"`
+	// EventTime is the timestamp associated with the matchup
+	EventTime time.Time `json:"event_time"`
+	// EventTimeParquet is the timestamp associated with the matchup (in milliseconds)
+	EventTimeParquet int64 `json:"-" parquet:"name=event_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// PlayID
+	PlayID string `json:"play_id" parquet:"name=play_id, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// Inning
+	Inning int32 `json:"inning" parquet:"name=inning, type=INT32"`
+	// AtBatNum
+	AtBatNum int32 `json:"at_bat_number" parquet:"name=at_bat_number, type=INT32"`
+	// Strikes
+	Strikes int32 `json:"strikes" parquet:"name=strikes, type=INT32"`
+	// Balls
+	Balls int32 `json:"balls" parquet:"name=balls, type=INT32"`
+	// Outs
+	Outs int32 `json:"outs" parquet:"name=outs, type=INT32"`
+	// PreStrikes - the number of strikes before the current play
+	PreStrikes int32 `json:"pre_strikes" parquet:"name=pre_strikes, type=INT32"`
+	// PreBalls - the number of balls before the current play
+	PreBalls int32 `json:"pre_balls" parquet:"name=pre_balls, type=INT32"`
+	// BatterID
+	BatterID int64 `json:"batter_id" parquet:"name=batter_id, type=INT64"`
+	// BatterStand - the abbreviation of the side of the home plate the batter is standing
+	// R = the first-base side of the home plate, L = the third-base side of home plate
+	BatterStand string `json:"batter_stand" parquet:"name=batter_stand, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// BatterName
+	BatterName string `json:"batter_name" parquet:"name=batter_name, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// PitcherID
+	PitcherID int64 `json:"pitcher_id" parquet:"name=pitcher_id, type=INT32"`
+	// PitcherThrow - https://www.mlb.com/glossary/pitch-types
+	PitcherThrow string `json:"pitcher_throw" parquet:"name=pitcher_throw, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// PitcherName
+	PitcherName string `json:"pitcher_name" parquet:"name=pitcher_name, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// Result - the terminal outcome of the batter
+	Result *string `json:"result" parquet:"name=result, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// ResultDescription extrapolates on Result
+	ResultDescription *string `json:"result_description" parquet:"name=result_description, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// PitchType
+	PitchType string `json:"pitch_type" parquet:"name=pitch_type, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// PitchName
+	PitchName string `json:"pitch_name" parquet:"name=pitch_name, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// CallName is the call on the play
+	CallName string `json:"call_name" parquet:"name=call_name, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// CallDescription
+	CallDescription string `json:"call_description" parquet:"name=call_description, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// IsStrikeSwinging
+	IsStrikeSwinging bool `json:"is_strike_swinging" parquet:"name=is_strike_swinging, type=BOOLEAN"`
+	// PitchStartSpeed
+	PitchStartSpeed float32 `json:"pitch_start_speed" parquet:"name=pitch_start_speed, type=FLOAT"`
+	// PitchEndSpeed
+	PitchEndSpeed float32 `json:"pitch_end_speed" parquet:"name=pitch_end_speed, type=FLOAT"`
+	// PitchNumber
+	PitchNumber int32 `json:"pitch_number" parquet:"name=pitch_number, type=INT32"`
+	// PitcherTotalPitches
+	PitcherTotalPitches int32 `json:"pitcher_total_pitches" parquet:"name=pitcher_total_pitches, type=INT32"`
+	// PitcherTotalPitchesByPitchType
+	PitcherTotalPitchesByPitchType int32 `json:"pitcher_total_pitches_by_pitch_type" parquet:"name=pitcher_total_pitches_by_pitch_type, type=INT32"`
+	// GameTotalPitches
+	GameTotalPitches int32 `json:"game_total_pitches" parquet:"name=game_total_pitches, type=INT32"`
+	// HitSpeed
+	HitSpeed *float32 `json:"hit_speed" parquet:"name=hit_speed, type=FLOAT"`
+	// HitDistance
+	HitDistance *int32 `json:"hit_distance" parquet:"name=hit_distance, type=INT32"`
+}

--- a/dataprovider/baseballsavantmlb/scraper_batting_box_score.go
+++ b/dataprovider/baseballsavantmlb/scraper_batting_box_score.go
@@ -1,0 +1,165 @@
+package baseballsavantmlb
+
+import (
+	"log"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/jsonresponse"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	"github.com/xitongsys/parquet-go/types"
+)
+
+// BattingBoxScoreScraperOption defines a configuration option for the scraper
+type BattingBoxScoreScraperOption func(*BattingBoxScoreScraper)
+
+// NewBattingBoxScoreScraper creates a new BattingBoxScoreScraper with the provided options
+func NewBattingBoxScoreScraper(options ...BattingBoxScoreScraperOption) *BattingBoxScoreScraper {
+	s := &BattingBoxScoreScraper{}
+
+	// Apply all options
+	for _, option := range options {
+		option(s)
+	}
+	s.Init()
+
+	return s
+}
+
+type BattingBoxScoreScraper struct {
+	EventDataScraper
+}
+
+func (s BattingBoxScoreScraper) Feed() sportscrape.Feed {
+	return sportscrape.BaseballSavantMLBBattingBoxScore
+}
+
+func (s BattingBoxScoreScraper) Scrape(matchup interface{}) sportscrape.EventDataOutput {
+	matchupmodel := matchup.(model.Matchup)
+	context := s.ConstructContext(matchupmodel)
+	url := ConstructEventDataURL(matchupmodel.EventID)
+	context.URL = url
+	pullTimestamp := time.Now().UTC()
+	gf, err := s.FetchGameFeed(url)
+	if err != nil {
+		log.Println("Issue fetching event data")
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	context.PullTimestamp = pullTimestamp
+	var data []interface{}
+	// home batters
+	res, err := s.constructBatting("home", gf.HomeBatters, gf, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if res != nil {
+		data = append(data, res...)
+	}
+	// away batters
+	res, err = s.constructBatting("away", gf.AwayBatters, gf, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if res != nil {
+		data = append(data, res...)
+	}
+	return sportscrape.EventDataOutput{Error: err, Context: context, Output: data}
+}
+
+func (s BattingBoxScoreScraper) constructBatting(team string, plays *jsonresponse.Plays, gf jsonresponse.GameFeed, context sportscrape.EventDataContext) ([]interface{}, error) {
+	if plays == nil {
+		return nil, nil
+	}
+	var teamName, opponentName string
+	var teamid, opponentid int64
+	var boxscoreteam jsonresponse.BoxScoreTeam
+	var data []interface{}
+	var err error
+	eventid := context.EventID.(int64)
+	switch team {
+	case "home":
+		teamName = context.HomeTeam
+		teamid = context.HomeID.(int64)
+		boxscoreteam = gf.BoxScore.Teams.Home
+		opponentName = context.AwayTeam
+		opponentid = context.AwayID.(int64)
+	default:
+		teamName = context.AwayTeam
+		teamid = context.AwayID.(int64)
+		boxscoreteam = gf.BoxScore.Teams.Away
+		opponentName = context.HomeTeam
+		opponentid = context.HomeID.(int64)
+	}
+	for playerid := range *plays {
+		fmtID := s.FmtID(playerid)
+		player, exists := boxscoreteam.Players[fmtID]
+		if !exists {
+			log.Printf("No batting box score data available for player %s\n", playerid)
+			continue
+		}
+		if player.Stats.Batting.AtBatsPerHomeRun == "" || player.Stats.Batting.StolenBasePercentage == "" {
+			log.Printf("No batting box score data available for player %s\n", playerid)
+			continue
+		}
+		var ab_hr float32
+
+		ab_hr_str := player.Stats.Batting.AtBatsPerHomeRun
+
+		if ab_hr_str == "-.--" {
+			ab_hr = float32(0)
+		} else {
+			ab_hr, err = util.TextToFloat32(player.Stats.Batting.AtBatsPerHomeRun)
+			if err != nil {
+				log.Printf("Issue parsing AB/HR %s\n", player.Stats.Batting.AtBatsPerHomeRun)
+				return nil, err
+			}
+		}
+
+		box_score := model.BattingBoxScore{
+			PullTimestamp:        context.PullTimestamp,
+			PullTimestampParquet: types.TimeToTIMESTAMP_MILLIS(context.PullTimestamp, true),
+			EventTime:            context.EventTime,
+			EventTimeParquet:     types.TimeToTIMESTAMP_MILLIS(context.EventTime, true),
+			EventID:              eventid,
+			TeamID:               teamid,
+			Team:                 teamName,
+			Opponent:             opponentName,
+			OpponentID:           opponentid,
+			PlayerID:             player.Person.ID,
+			Player:               player.Person.Name,
+			Position:             player.Position.Name,
+			FlyOuts:              player.Stats.Batting.FlyOuts,
+			GroundOuts:           player.Stats.Batting.GroundOuts,
+			AirOuts:              player.Stats.Batting.AirOuts,
+			Runs:                 player.Stats.Batting.Runs,
+			Doubles:              player.Stats.Batting.Doubles,
+			Triples:              player.Stats.Batting.Triples,
+			HomeRuns:             player.Stats.Batting.HomeRuns,
+			Strikeouts:           player.Stats.Batting.StrikeOuts,
+			Walks:                player.Stats.Batting.BaseOnBalls,
+			IntentionalWalks:     player.Stats.Batting.IntentionalWalks,
+			Hits:                 player.Stats.Batting.Hits,
+			HitByPitch:           player.Stats.Batting.HitByPitch,
+			AtBats:               player.Stats.Batting.AtBats,
+			CaughtStealing:       player.Stats.Batting.CaughtStealing,
+			StolenBases:          player.Stats.Batting.StolenBases,
+			GroundIntoDoublePlay: player.Stats.Batting.GroundIntoDoublePlay,
+			GroundIntoTriplePlay: player.Stats.Batting.GroundIntoTriplePlay,
+			PlateAppearances:     player.Stats.Batting.PlateAppearances,
+			TotalBases:           player.Stats.Batting.TotalBases,
+			RBI:                  player.Stats.Batting.RBI,
+			LeftOnBase:           player.Stats.Batting.LeftOnBase,
+			SacBunts:             player.Stats.Batting.SacBunts,
+			SacFlies:             player.Stats.Batting.SacFlies,
+			CatchersInterference: player.Stats.Batting.CatchersInterference,
+			Pickoffs:             player.Stats.Batting.Pickoffs,
+			AtBatsPerHomeRun:     ab_hr,
+			PopOuts:              player.Stats.Batting.PopOuts,
+			LineOuts:             player.Stats.Batting.LineOuts,
+		}
+		data = append(data, box_score)
+	}
+	return data, nil
+
+}

--- a/dataprovider/baseballsavantmlb/scraper_batting_box_score_test.go
+++ b/dataprovider/baseballsavantmlb/scraper_batting_box_score_test.go
@@ -1,0 +1,78 @@
+//go:build integration
+
+package baseballsavantmlb
+
+import (
+	"testing"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMLBBattingBoxScoreScraper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	matchupscraper := NewMatchupScraper(
+		MatchupScraperDate("2024-10-30"),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	assert.NoError(t, err)
+
+	boxscorescraper := NewBattingBoxScoreScraper()
+	boxscorerunner := sportscrape.NewEventDataRunner(
+		sportscrape.EventDataRunnerScraper(boxscorescraper),
+		sportscrape.EventDataRunnerConcurrency(1),
+	)
+	boxScoreStats, err := boxscorerunner.Run(matchups...)
+	assert.NoError(t, err)
+	assert.Equal(t, 18, len(boxScoreStats), "18 statlines")
+	GavinLuxTested := false
+	for _, statline := range boxScoreStats {
+		s := statline.(model.BattingBoxScore)
+		if s.Player == "Gavin Lux" {
+			GavinLuxTested = true
+			assert.Equal(t, int64(775296), s.EventID)
+			assert.Equal(t, int64(119), s.TeamID)
+			assert.Equal(t, "Los Angeles Dodgers", s.Team)
+			assert.Equal(t, "New York Yankees", s.Opponent)
+			assert.Equal(t, int64(147), s.OpponentID)
+			assert.Equal(t, int64(666158), s.PlayerID)
+			assert.Equal(t, "Second Base", s.Position)
+			assert.Equal(t, int32(2), s.FlyOuts)
+			assert.Equal(t, int32(0), s.GroundOuts)
+			assert.Equal(t, int32(2), s.AirOuts)
+			assert.Equal(t, int32(0), s.Runs)
+			assert.Equal(t, int32(0), s.Doubles)
+			assert.Equal(t, int32(0), s.Triples)
+			assert.Equal(t, int32(0), s.HomeRuns)
+			assert.Equal(t, int32(1), s.Strikeouts)
+			assert.Equal(t, int32(1), s.Walks)
+			assert.Equal(t, int32(0), s.IntentionalWalks)
+			assert.Equal(t, int32(0), s.Hits)
+			assert.Equal(t, int32(0), s.HitByPitch)
+			assert.Equal(t, int32(2), s.AtBats)
+			assert.Equal(t, int32(0), s.CaughtStealing)
+			assert.Equal(t, int32(0), s.StolenBases)
+			assert.Equal(t, int32(0), s.GroundIntoDoublePlay)
+			assert.Equal(t, int32(0), s.GroundIntoTriplePlay)
+			assert.Equal(t, int32(4), s.PlateAppearances)
+			assert.Equal(t, int32(0), s.TotalBases)
+			assert.Equal(t, int32(1), s.RBI)
+			assert.Equal(t, int32(3), s.LeftOnBase)
+			assert.Equal(t, int32(0), s.SacBunts)
+			assert.Equal(t, int32(1), s.SacFlies)
+			assert.Equal(t, int32(0), s.CatchersInterference)
+			assert.Equal(t, int32(0), s.Pickoffs)
+			assert.Equal(t, float32(0), s.AtBatsPerHomeRun)
+			assert.Equal(t, int32(0), s.PopOuts)
+			assert.Equal(t, int32(0), s.LineOuts)
+		}
+	}
+	assert.True(t, GavinLuxTested, "Gavin Lux statline tested")
+
+}

--- a/dataprovider/baseballsavantmlb/scraper_event_data.go
+++ b/dataprovider/baseballsavantmlb/scraper_event_data.go
@@ -1,0 +1,52 @@
+package baseballsavantmlb
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/jsonresponse"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/lightning-dabbler/sportscrape/util/request"
+)
+
+type EventDataScraper struct{}
+
+func (e EventDataScraper) Init() {}
+
+func (e EventDataScraper) ConstructContext(matchup model.Matchup) sportscrape.EventDataContext {
+	return sportscrape.EventDataContext{
+		AwayTeam:  matchup.AwayTeamName,
+		AwayID:    matchup.AwayTeamID,
+		HomeTeam:  matchup.HomeTeamName,
+		HomeID:    matchup.HomeTeamID,
+		EventTime: matchup.EventTime,
+		EventID:   matchup.EventID,
+	}
+}
+
+func (e EventDataScraper) FetchGameFeed(url string) (jsonresponse.GameFeed, error) {
+	var responsePayload jsonresponse.GameFeed
+	response, err := request.Get(url)
+	if err != nil {
+		return responsePayload, err
+	}
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return responsePayload, err
+	}
+	err = json.Unmarshal(responseBody, &responsePayload)
+	if err != nil {
+		return responsePayload, err
+	}
+	return responsePayload, nil
+}
+
+func (e EventDataScraper) Provider() sportscrape.Provider {
+	return sportscrape.BaseballSavant
+}
+
+func (e EventDataScraper) FmtID(playerid string) string {
+	return "ID" + playerid
+}

--- a/dataprovider/baseballsavantmlb/scraper_fielding_box_score.go
+++ b/dataprovider/baseballsavantmlb/scraper_fielding_box_score.go
@@ -1,0 +1,146 @@
+package baseballsavantmlb
+
+import (
+	"log"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/jsonresponse"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/xitongsys/parquet-go/types"
+)
+
+// FieldingBoxScoreScraperOption defines a configuration option for the scraper
+type FieldingBoxScoreScraperOption func(*FieldingBoxScoreScraper)
+
+// NewFieldingBoxScoreScraper creates a new FieldingBoxScoreScraper with the provided options
+func NewFieldingBoxScoreScraper(options ...FieldingBoxScoreScraperOption) *FieldingBoxScoreScraper {
+	s := &FieldingBoxScoreScraper{}
+
+	// Apply all options
+	for _, option := range options {
+		option(s)
+	}
+	s.Init()
+
+	return s
+}
+
+type FieldingBoxScoreScraper struct {
+	EventDataScraper
+}
+
+func (s FieldingBoxScoreScraper) Feed() sportscrape.Feed {
+	return sportscrape.BaseballSavantMLBFieldingBoxScore
+}
+
+func (s FieldingBoxScoreScraper) Scrape(matchup interface{}) sportscrape.EventDataOutput {
+	matchupmodel := matchup.(model.Matchup)
+	context := s.ConstructContext(matchupmodel)
+	url := ConstructEventDataURL(matchupmodel.EventID)
+	context.URL = url
+	pullTimestamp := time.Now().UTC()
+	gf, err := s.FetchGameFeed(url)
+	if err != nil {
+		log.Println("Issue fetching event data")
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	context.PullTimestamp = pullTimestamp
+	var data []interface{}
+	// home pitchers
+	res, err := s.constructFielding("home", gf.HomePitchers, gf, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if res != nil {
+		data = append(data, res...)
+	}
+	// home batters
+	res, err = s.constructFielding("home", gf.HomeBatters, gf, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if res != nil {
+		data = append(data, res...)
+	}
+	// away pitchers
+	res, err = s.constructFielding("away", gf.AwayPitchers, gf, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if res != nil {
+		data = append(data, res...)
+	}
+	// away batters
+	res, err = s.constructFielding("away", gf.AwayBatters, gf, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if res != nil {
+		data = append(data, res...)
+	}
+	return sportscrape.EventDataOutput{Error: err, Context: context, Output: data}
+}
+
+func (s FieldingBoxScoreScraper) constructFielding(team string, plays *jsonresponse.Plays, gf jsonresponse.GameFeed, context sportscrape.EventDataContext) ([]interface{}, error) {
+	if plays == nil {
+		return nil, nil
+	}
+	var teamName, opponentName string
+	var teamid, opponentid int64
+	var boxscoreteam jsonresponse.BoxScoreTeam
+	var data []interface{}
+	eventid := context.EventID.(int64)
+	switch team {
+	case "home":
+		teamName = context.HomeTeam
+		teamid = context.HomeID.(int64)
+		boxscoreteam = gf.BoxScore.Teams.Home
+		opponentName = context.AwayTeam
+		opponentid = context.AwayID.(int64)
+	default:
+		teamName = context.AwayTeam
+		teamid = context.AwayID.(int64)
+		boxscoreteam = gf.BoxScore.Teams.Away
+		opponentName = context.HomeTeam
+		opponentid = context.HomeID.(int64)
+	}
+	for playerid := range *plays {
+		fmtID := s.FmtID(playerid)
+		player, exists := boxscoreteam.Players[fmtID]
+		if !exists {
+			log.Printf("No fielding box score data available for player %s\n", playerid)
+			continue
+		}
+		if player.Stats.Fielding.Fielding == "" || player.Stats.Fielding.StolenBasePercentage == "" {
+			log.Printf("No fielding box score data available for player %s\n", playerid)
+			continue
+		}
+
+		box_score := model.FieldingBoxScore{
+			PullTimestamp:        context.PullTimestamp,
+			PullTimestampParquet: types.TimeToTIMESTAMP_MILLIS(context.PullTimestamp, true),
+			EventTime:            context.EventTime,
+			EventTimeParquet:     types.TimeToTIMESTAMP_MILLIS(context.EventTime, true),
+			EventID:              eventid,
+			TeamID:               teamid,
+			Team:                 teamName,
+			Opponent:             opponentName,
+			OpponentID:           opponentid,
+			PlayerID:             player.Person.ID,
+			Player:               player.Person.Name,
+			Position:             player.Position.Name,
+			CaughtStealing:       player.Stats.Fielding.CaughtStealing,
+			StolenBases:          player.Stats.Fielding.StolenBases,
+			Assists:              player.Stats.Fielding.Assists,
+			Putouts:              player.Stats.Fielding.PutOuts,
+			Errors:               player.Stats.Fielding.Errors,
+			Chances:              player.Stats.Fielding.Chances,
+			PassedBall:           player.Stats.Fielding.PassedBall,
+			Pickoffs:             player.Stats.Fielding.Pickoffs,
+		}
+		data = append(data, box_score)
+	}
+	return data, nil
+
+}

--- a/dataprovider/baseballsavantmlb/scraper_fielding_box_score_test.go
+++ b/dataprovider/baseballsavantmlb/scraper_fielding_box_score_test.go
@@ -1,0 +1,62 @@
+//go:build integration
+
+package baseballsavantmlb
+
+import (
+	"testing"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFieldingBoxScoreScraper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	date := "2024-10-07"
+	matchupscraper := NewMatchupScraper(
+		MatchupScraperDate(date),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	assert.NoError(t, err)
+
+	boxscorescraper := NewFieldingBoxScoreScraper()
+	boxscorerunner := sportscrape.NewEventDataRunner(
+		sportscrape.EventDataRunnerScraper(boxscorescraper),
+		sportscrape.EventDataRunnerConcurrency(1),
+	)
+	boxScoreStats, err := boxscorerunner.Run(matchups...)
+	assert.NoError(t, err)
+	assert.Equal(t, 64, len(boxScoreStats), "64 statlines")
+
+	playerToTest := map[string]bool{
+		"Austin Wells": false,
+	}
+	for _, statline := range boxScoreStats {
+		stats := statline.(model.FieldingBoxScore)
+		if stats.Player == "Austin Wells" {
+			playerToTest[stats.Player] = true
+			assert.Equal(t, int64(775332), stats.EventID)
+			assert.Equal(t, int64(147), stats.TeamID)
+			assert.Equal(t, "New York Yankees", stats.Team)
+			assert.Equal(t, "Kansas City Royals", stats.Opponent)
+			assert.Equal(t, int64(118), stats.OpponentID)
+			assert.Equal(t, int64(669224), stats.PlayerID)
+			assert.Equal(t, "Austin Wells", stats.Player)
+			assert.Equal(t, "Catcher", stats.Position)
+			assert.Equal(t, int32(1), stats.CaughtStealing)
+			assert.Equal(t, int32(2), stats.StolenBases)
+			assert.Equal(t, int32(1), stats.Assists)
+			assert.Equal(t, int32(15), stats.Putouts)
+			assert.Equal(t, int32(0), stats.Errors)
+			assert.Equal(t, int32(16), stats.Chances)
+			assert.Equal(t, int32(0), stats.PassedBall)
+			assert.Equal(t, int32(0), stats.Pickoffs)
+		}
+	}
+	assert.True(t, playerToTest["Austin Wells"], "Austin Wells's fielding stats were collected")
+}

--- a/dataprovider/baseballsavantmlb/scraper_matchups.go
+++ b/dataprovider/baseballsavantmlb/scraper_matchups.go
@@ -1,0 +1,153 @@
+package baseballsavantmlb
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/jsonresponse"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	"github.com/lightning-dabbler/sportscrape/util/request"
+	"github.com/xitongsys/parquet-go/types"
+)
+
+// MatchupScraperOption defines a configuration option for the scraper
+type MatchupScraperOption func(*MatchupScraper)
+
+// MatchupScraperDate sets the date option
+func MatchupScraperDate(date string) MatchupScraperOption {
+	return func(s *MatchupScraper) {
+		s.Date = date
+	}
+}
+
+// NewMatchupScraper creates a new MatchupScraper with the provided options
+func NewMatchupScraper(options ...MatchupScraperOption) *MatchupScraper {
+	s := &MatchupScraper{}
+
+	// Apply all options
+	for _, option := range options {
+		option(s)
+	}
+	s.Init()
+
+	return s
+}
+
+type MatchupScraper struct {
+	Date string
+}
+
+func (s MatchupScraper) Init() {
+	if s.Date == "" {
+		log.Fatalln("Date is a required argument")
+	}
+}
+
+func (s MatchupScraper) Provider() sportscrape.Provider {
+	return sportscrape.BaseballSavant
+}
+
+func (s MatchupScraper) Feed() sportscrape.Feed {
+	return sportscrape.BaseballSavantMLBMatchup
+}
+
+func (s MatchupScraper) Scrape() sportscrape.MatchupOutput {
+	var matchups []interface{}
+	output := sportscrape.MatchupOutput{}
+
+	url, err := ConstructMatchupURL(s.Date)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+
+	var jsonobj jsonresponse.Matchups
+	pullTimestamp := time.Now().UTC()
+	response, err := request.Get(url)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+	err = json.Unmarshal(body, &jsonobj)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+
+	for _, game := range jsonobj.Schedule.Dates[0].Games {
+		season, err := util.TextToInt32(game.Season)
+		if err != nil {
+			log.Printf("error converting season from string to int32: %s", game.Season)
+			output.Error = err
+			return output
+		}
+		eventTime, err := util.RFC3339ToTime(game.EventTime)
+		if err != nil {
+			log.Printf("error parsing EventTime: %s", game.EventTime)
+			output.Error = err
+			return output
+		}
+		matchup := model.Matchup{
+			PullTimestamp:        pullTimestamp,
+			PullTimestampParquet: types.TimeToTIMESTAMP_MILLIS(pullTimestamp, true),
+			EventTime:            eventTime,
+			EventTimeParquet:     types.TimeToTIMESTAMP_MILLIS(eventTime, true),
+			EventID:              game.EventID,
+			Status:               game.Status.DetailedState,
+
+			HomeTeamID:           game.Teams.Home.Team.ID,
+			HomeTeamAbbreviation: game.Teams.Home.Team.Abbreviation,
+			HomeTeamName:         game.Teams.Home.Team.Name,
+			HomeWins:             game.Teams.Home.LeagueRecord.Wins,
+			HomeLosses:           game.Teams.Home.LeagueRecord.Losses,
+
+			AwayTeamID:           game.Teams.Away.Team.ID,
+			AwayTeamAbbreviation: game.Teams.Away.Team.Abbreviation,
+			AwayTeamName:         game.Teams.Away.Team.Name,
+			AwayWins:             game.Teams.Away.LeagueRecord.Wins,
+			AwayLosses:           game.Teams.Away.LeagueRecord.Losses,
+
+			GameType:          game.GameType,
+			SeriesDescription: game.SeriesDescription,
+			GamesInSeries:     game.GamesInSeries,
+			SeriesGameNumber:  game.SeriesGameNumber,
+			Season:            season,
+		}
+
+		if game.Teams.Home.Score != nil {
+			matchup.HomeScore = game.Teams.Home.Score
+		}
+		if game.Teams.Home.ProbablePitcher != nil {
+			matchup.HomeStartingPitcherID = &game.Teams.Home.ProbablePitcher.ID
+			matchup.HomeStartingPitcher = &game.Teams.Home.ProbablePitcher.Name
+		}
+
+		if game.Teams.Away.Score != nil {
+			matchup.AwayScore = game.Teams.Away.Score
+		}
+		if game.Teams.Away.ProbablePitcher != nil {
+			matchup.AwayStartingPitcherID = &game.Teams.Away.ProbablePitcher.ID
+			matchup.AwayStartingPitcher = &game.Teams.Away.ProbablePitcher.Name
+		}
+
+		if game.Teams.Away.IsWinner != nil && *game.Teams.Away.IsWinner {
+			matchup.Loser = &game.Teams.Away.Team.ID
+		}
+		if game.Teams.Home.IsWinner != nil && *game.Teams.Home.IsWinner {
+			matchup.Loser = &game.Teams.Home.Team.ID
+		}
+
+		matchups = append(matchups, matchup)
+	}
+	output.Output = matchups
+	return output
+}

--- a/dataprovider/baseballsavantmlb/scraper_matchups_test.go
+++ b/dataprovider/baseballsavantmlb/scraper_matchups_test.go
@@ -1,0 +1,56 @@
+//go:build integration
+
+package baseballsavantmlb
+
+import (
+	"testing"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMatchupScraper_NBA(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	matchupscraper := NewMatchupScraper(
+		MatchupScraperDate("2024-10-18"),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	assert.NoError(t, err)
+	n_matchups := len(matchups)
+	assert.Equal(t, 2, n_matchups, "2 events")
+	testMatchup := matchups[1].(model.Matchup)
+	assert.Equal(t, int64(775311), testMatchup.EventID)
+	assert.Equal(t, "Final", testMatchup.Status)
+
+	assert.Equal(t, int64(114), testMatchup.HomeTeamID)
+	assert.Equal(t, "CLE", testMatchup.HomeTeamAbbreviation)
+	assert.Equal(t, "Cleveland Guardians", testMatchup.HomeTeamName)
+	assert.Equal(t, "Gavin Williams", *testMatchup.HomeStartingPitcher)
+	assert.Equal(t, int64(668909), *testMatchup.HomeStartingPitcherID)
+	assert.Equal(t, int32(1), testMatchup.HomeWins)
+	assert.Equal(t, int32(3), testMatchup.HomeLosses)
+	assert.Equal(t, int32(6), *testMatchup.HomeScore)
+
+	assert.Equal(t, int64(147), testMatchup.AwayTeamID)
+	assert.Equal(t, "NYY", testMatchup.AwayTeamAbbreviation)
+	assert.Equal(t, "New York Yankees", testMatchup.AwayTeamName)
+	assert.Equal(t, "Luis Gil", *testMatchup.AwayStartingPitcher)
+	assert.Equal(t, int64(661563), *testMatchup.AwayStartingPitcherID)
+	assert.Equal(t, int32(3), testMatchup.AwayWins)
+	assert.Equal(t, int32(1), testMatchup.AwayLosses)
+	assert.Equal(t, int32(8), *testMatchup.AwayScore)
+
+	assert.Equal(t, int64(147), *testMatchup.Loser)
+	assert.Equal(t, "L", testMatchup.GameType)
+	assert.Equal(t, "League Championship Series", testMatchup.SeriesDescription)
+	assert.Equal(t, int32(7), testMatchup.GamesInSeries)
+	assert.Equal(t, int32(4), testMatchup.SeriesGameNumber)
+	assert.Equal(t, int32(2024), testMatchup.Season)
+
+}

--- a/dataprovider/baseballsavantmlb/scraper_pitching_box_score.go
+++ b/dataprovider/baseballsavantmlb/scraper_pitching_box_score.go
@@ -1,0 +1,170 @@
+package baseballsavantmlb
+
+import (
+	"log"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/jsonresponse"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	"github.com/xitongsys/parquet-go/types"
+)
+
+// PitchingBoxScoreScraperOption defines a configuration option for the scraper
+type PitchingBoxScoreScraperOption func(*PitchingBoxScoreScraper)
+
+// NewPitchingBoxScoreScraper creates a new PitchingBoxScoreScraper with the provided options
+func NewPitchingBoxScoreScraper(options ...PitchingBoxScoreScraperOption) *PitchingBoxScoreScraper {
+	s := &PitchingBoxScoreScraper{}
+
+	// Apply all options
+	for _, option := range options {
+		option(s)
+	}
+	s.Init()
+
+	return s
+}
+
+type PitchingBoxScoreScraper struct {
+	EventDataScraper
+}
+
+func (s PitchingBoxScoreScraper) Feed() sportscrape.Feed {
+	return sportscrape.BaseballSavantMLBPitchingBoxScore
+}
+
+func (s PitchingBoxScoreScraper) Scrape(matchup interface{}) sportscrape.EventDataOutput {
+	matchupmodel := matchup.(model.Matchup)
+	context := s.ConstructContext(matchupmodel)
+	url := ConstructEventDataURL(matchupmodel.EventID)
+	context.URL = url
+	pullTimestamp := time.Now().UTC()
+	gf, err := s.FetchGameFeed(url)
+	if err != nil {
+		log.Println("Issue fetching event data")
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	context.PullTimestamp = pullTimestamp
+	var data []interface{}
+	// home pitchers
+	res, err := s.constructPitching("home", gf.HomePitchers, gf, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if res != nil {
+		data = append(data, res...)
+	}
+	// away pitchers
+	res, err = s.constructPitching("away", gf.AwayPitchers, gf, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if res != nil {
+		data = append(data, res...)
+	}
+	return sportscrape.EventDataOutput{Error: err, Context: context, Output: data}
+}
+
+func (s PitchingBoxScoreScraper) constructPitching(team string, plays *jsonresponse.Plays, gf jsonresponse.GameFeed, context sportscrape.EventDataContext) ([]interface{}, error) {
+	if plays == nil {
+		return nil, nil
+	}
+	var teamName, opponentName string
+	var teamid, opponentid int64
+	var boxscoreteam jsonresponse.BoxScoreTeam
+	var data []interface{}
+	var err error
+	eventid := context.EventID.(int64)
+	switch team {
+	case "home":
+		teamName = context.HomeTeam
+		teamid = context.HomeID.(int64)
+		boxscoreteam = gf.BoxScore.Teams.Home
+		opponentName = context.AwayTeam
+		opponentid = context.AwayID.(int64)
+	default:
+		teamName = context.AwayTeam
+		teamid = context.AwayID.(int64)
+		boxscoreteam = gf.BoxScore.Teams.Away
+		opponentName = context.HomeTeam
+		opponentid = context.HomeID.(int64)
+	}
+	for playerid := range *plays {
+		fmtID := s.FmtID(playerid)
+		player, exists := boxscoreteam.Players[fmtID]
+		if !exists {
+			log.Printf("No pitching box score data available for player %s\n", playerid)
+			continue
+		}
+		if player.Stats.Pitching.RunsScoredPer9 == "" || player.Stats.Pitching.StolenBasePercentage == "" {
+			log.Printf("No pitching box score data available for player %s\n", playerid)
+			continue
+		}
+		var ip float32
+
+		ip, err = util.TextToFloat32(player.Stats.Pitching.InningsPitched)
+		if err != nil {
+			log.Printf("Issue parsing innings pitched %s\n", player.Stats.Pitching.InningsPitched)
+			return nil, err
+		}
+
+		box_score := model.PitchingBoxScore{
+			PullTimestamp:          context.PullTimestamp,
+			PullTimestampParquet:   types.TimeToTIMESTAMP_MILLIS(context.PullTimestamp, true),
+			EventTime:              context.EventTime,
+			EventTimeParquet:       types.TimeToTIMESTAMP_MILLIS(context.EventTime, true),
+			EventID:                eventid,
+			TeamID:                 teamid,
+			Team:                   teamName,
+			Opponent:               opponentName,
+			OpponentID:             opponentid,
+			PlayerID:               player.Person.ID,
+			Player:                 player.Person.Name,
+			Position:               player.Position.Name,
+			FlyOuts:                player.Stats.Pitching.FlyOuts,
+			GroundOuts:             player.Stats.Pitching.GroundOuts,
+			AirOuts:                player.Stats.Pitching.AirOuts,
+			Runs:                   player.Stats.Pitching.Runs,
+			Doubles:                player.Stats.Pitching.Doubles,
+			Triples:                player.Stats.Pitching.Triples,
+			HomeRuns:               player.Stats.Pitching.HomeRuns,
+			Strikeouts:             player.Stats.Pitching.StrikeOuts,
+			Walks:                  player.Stats.Pitching.BaseOnBalls,
+			IntentionalWalks:       player.Stats.Pitching.IntentionalWalks,
+			Hits:                   player.Stats.Pitching.Hits,
+			HitByPitch:             player.Stats.Pitching.HitByPitch,
+			AtBats:                 player.Stats.Pitching.AtBats,
+			CaughtStealing:         player.Stats.Pitching.CaughtStealing,
+			StolenBases:            player.Stats.Pitching.StolenBases,
+			NumberOfPitches:        player.Stats.Pitching.NumberOfPitches,
+			InningsPitched:         ip,
+			Wins:                   player.Stats.Pitching.Wins,
+			Losses:                 player.Stats.Pitching.Losses,
+			Saves:                  player.Stats.Pitching.Saves,
+			BlownSaves:             player.Stats.Pitching.BlownSaves,
+			EarnedRuns:             player.Stats.Pitching.EarnedRuns,
+			BattersFaced:           player.Stats.Pitching.BattersFaced,
+			Outs:                   player.Stats.Pitching.Outs,
+			Shutouts:               player.Stats.Pitching.Shutouts,
+			Balls:                  player.Stats.Pitching.Balls,
+			Strikes:                player.Stats.Pitching.Strikes,
+			Balks:                  player.Stats.Pitching.Balks,
+			WildPitches:            player.Stats.Pitching.WildPitches,
+			Pickoffs:               player.Stats.Pitching.Pickoffs,
+			RBI:                    player.Stats.Pitching.RBI,
+			InheritedRunners:       player.Stats.Pitching.InheritedRunners,
+			InheritedRunnersScored: player.Stats.Pitching.InheritedRunnersScored,
+			CatchersInterference:   player.Stats.Pitching.CatchersInterference,
+			SacBunts:               player.Stats.Pitching.SacBunts,
+			SacFlies:               player.Stats.Pitching.SacFlies,
+			PassedBall:             player.Stats.Pitching.PassedBall,
+			PopOuts:                player.Stats.Pitching.PopOuts,
+			LineOuts:               player.Stats.Pitching.LineOuts,
+		}
+		data = append(data, box_score)
+	}
+	return data, nil
+
+}

--- a/dataprovider/baseballsavantmlb/scraper_pitching_box_score_test.go
+++ b/dataprovider/baseballsavantmlb/scraper_pitching_box_score_test.go
@@ -1,0 +1,86 @@
+package baseballsavantmlb
+
+import (
+	"testing"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMLBPitchingBoxScoreScraper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	matchupscraper := NewMatchupScraper(
+		MatchupScraperDate("2024-10-30"),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	assert.NoError(t, err)
+
+	boxscorescraper := NewPitchingBoxScoreScraper()
+	boxscorerunner := sportscrape.NewEventDataRunner(
+		sportscrape.EventDataRunnerScraper(boxscorescraper),
+		sportscrape.EventDataRunnerConcurrency(1),
+	)
+	boxScoreStats, err := boxscorerunner.Run(matchups...)
+	assert.NoError(t, err)
+	assert.Equal(t, 13, len(boxScoreStats), "13 statlines")
+	GerritColeTested := false
+	for _, statline := range boxScoreStats {
+		s := statline.(model.PitchingBoxScore)
+		if s.Player == "Gerrit Cole" {
+			GerritColeTested = true
+			assert.Equal(t, int64(775296), s.EventID)
+			assert.Equal(t, int64(147), s.TeamID)
+			assert.Equal(t, "New York Yankees", s.Team)
+			assert.Equal(t, "Los Angeles Dodgers", s.Opponent)
+			assert.Equal(t, int64(119), s.OpponentID)
+			assert.Equal(t, int64(543037), s.PlayerID)
+			assert.Equal(t, "Pitcher", s.Position)
+			assert.Equal(t, int32(6), s.FlyOuts)
+			assert.Equal(t, int32(6), s.GroundOuts)
+			assert.Equal(t, int32(10), s.AirOuts)
+			assert.Equal(t, int32(5), s.Runs)
+			assert.Equal(t, int32(1), s.Doubles)
+			assert.Equal(t, int32(0), s.Triples)
+			assert.Equal(t, int32(0), s.HomeRuns)
+			assert.Equal(t, int32(6), s.Strikeouts)
+			assert.Equal(t, int32(4), s.Walks)
+			assert.Equal(t, int32(0), s.IntentionalWalks)
+			assert.Equal(t, int32(4), s.Hits)
+			assert.Equal(t, int32(0), s.HitByPitch)
+			assert.Equal(t, int32(26), s.AtBats)
+			assert.Equal(t, int32(0), s.CaughtStealing)
+			assert.Equal(t, int32(0), s.StolenBases)
+			assert.Equal(t, int32(108), s.NumberOfPitches)
+			assert.Equal(t, float32(6.2), s.InningsPitched)
+			assert.Equal(t, int32(0), s.Wins)
+			assert.Equal(t, int32(0), s.Losses)
+			assert.Equal(t, int32(0), s.Saves)
+			assert.Equal(t, int32(0), s.BlownSaves)
+			assert.Equal(t, int32(0), s.EarnedRuns)
+			assert.Equal(t, int32(30), s.BattersFaced)
+			assert.Equal(t, int32(20), s.Outs)
+			assert.Equal(t, int32(0), s.Shutouts)
+			assert.Equal(t, int32(32), s.Balls)
+			assert.Equal(t, int32(76), s.Strikes)
+			assert.Equal(t, int32(0), s.Balks)
+			assert.Equal(t, int32(0), s.WildPitches)
+			assert.Equal(t, int32(0), s.Pickoffs)
+			assert.Equal(t, int32(5), s.RBI)
+			assert.Equal(t, int32(0), s.InheritedRunners)
+			assert.Equal(t, int32(0), s.InheritedRunnersScored)
+			assert.Equal(t, int32(0), s.CatchersInterference)
+			assert.Equal(t, int32(0), s.SacBunts)
+			assert.Equal(t, int32(0), s.SacFlies)
+			assert.Equal(t, int32(0), s.PassedBall)
+			assert.Equal(t, int32(1), s.PopOuts)
+			assert.Equal(t, int32(3), s.LineOuts)
+		}
+	}
+	assert.True(t, GerritColeTested, "Gerrit Cole statline tested")
+}

--- a/dataprovider/baseballsavantmlb/scraper_play_by_play.go
+++ b/dataprovider/baseballsavantmlb/scraper_play_by_play.go
@@ -1,0 +1,137 @@
+package baseballsavantmlb
+
+import (
+	"log"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/jsonresponse"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	"github.com/xitongsys/parquet-go/types"
+)
+
+// PlayByPlayScraperOption defines a configuration option for the scraper
+type PlayByPlayScraperOption func(*PlayByPlayScraper)
+
+// NewPlayByPlayScraper creates a new PlayByPlayScraper with the provided options
+func NewPlayByPlayScraper(options ...PlayByPlayScraperOption) *PlayByPlayScraper {
+	s := &PlayByPlayScraper{}
+
+	// Apply all options
+	for _, option := range options {
+		option(s)
+	}
+	s.Init()
+
+	return s
+}
+
+type PlayByPlayScraper struct {
+	EventDataScraper
+}
+
+func (s PlayByPlayScraper) Feed() sportscrape.Feed {
+	return sportscrape.BaseballSavantMLBPlayByPlay
+}
+
+func (s PlayByPlayScraper) Scrape(matchup interface{}) sportscrape.EventDataOutput {
+	matchupmodel := matchup.(model.Matchup)
+	context := s.ConstructContext(matchupmodel)
+	url := ConstructEventDataURL(matchupmodel.EventID)
+	context.URL = url
+	pullTimestamp := time.Now().UTC()
+	gf, err := s.FetchGameFeed(url)
+	if err != nil {
+		log.Println("Issue fetching event data")
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	context.PullTimestamp = pullTimestamp
+	var data []interface{}
+	// home pitchers
+	res, err := s.constructPlayByPlay(gf.HomePitchers, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if res != nil {
+		data = append(data, res...)
+	}
+	// away pitchers
+	res, err = s.constructPlayByPlay(gf.AwayPitchers, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if res != nil {
+		data = append(data, res...)
+	}
+	return sportscrape.EventDataOutput{Error: err, Context: context, Output: data}
+}
+
+func (s PlayByPlayScraper) constructPlayByPlay(plays *jsonresponse.Plays, context sportscrape.EventDataContext) ([]interface{}, error) {
+	if plays == nil {
+		return nil, nil
+	}
+	var data []interface{}
+	eventid := context.EventID.(int64)
+	for _, events := range *plays {
+		for _, event := range events {
+			playbyplay := model.PlayByPlay{
+				PullTimestamp:                  context.PullTimestamp,
+				PullTimestampParquet:           types.TimeToTIMESTAMP_MILLIS(context.PullTimestamp, true),
+				EventTime:                      context.EventTime,
+				EventTimeParquet:               types.TimeToTIMESTAMP_MILLIS(context.EventTime, true),
+				EventID:                        eventid,
+				PlayID:                         event.PlayID,
+				Inning:                         event.Inning,
+				AtBatNum:                       event.AtBatNum,
+				Strikes:                        event.Strikes,
+				Balls:                          event.Balls,
+				Outs:                           event.Outs,
+				PreStrikes:                     event.PreStrikes,
+				PreBalls:                       event.PreBalls,
+				BatterID:                       event.BatterID,
+				BatterStand:                    event.BatterStand,
+				BatterName:                     event.BatterName,
+				PitcherID:                      event.PitcherID,
+				PitcherThrow:                   event.PitcherThrow,
+				PitcherName:                    event.PitcherName,
+				PitchType:                      event.PitchType,
+				PitchName:                      event.PitchName,
+				CallName:                       event.CallName,
+				CallDescription:                event.CallDescription,
+				IsStrikeSwinging:               event.IsStrikeSwinging,
+				PitchStartSpeed:                event.PitchStartSpeed,
+				PitchEndSpeed:                  event.PitchEndSpeed,
+				PitchNumber:                    event.PitchNumber,
+				PitcherTotalPitches:            event.PitcherTotalPitches,
+				PitcherTotalPitchesByPitchType: event.PitcherTotalPitchesByPitchType,
+				GameTotalPitches:               event.GameTotalPitches,
+			}
+			if event.Result != nil {
+				playbyplay.Result = event.Result
+			}
+			if event.ResultDescription != nil {
+				playbyplay.ResultDescription = event.ResultDescription
+			}
+			if event.HitDistance != nil && *event.HitDistance != "" {
+				hitdistance, err := util.TextToInt32(*event.HitDistance)
+				if err != nil {
+					log.Printf("Issue parsing hit distance %s\n", *event.HitDistance)
+					return nil, err
+				}
+				playbyplay.HitDistance = &hitdistance
+			}
+			if event.HitSpeed != nil && *event.HitSpeed != "" {
+				hitspeed, err := util.TextToFloat32(*event.HitSpeed)
+				if err != nil {
+					log.Printf("Issue parsing hit speed %s\n", *event.HitSpeed)
+					return nil, err
+				}
+				playbyplay.HitSpeed = &hitspeed
+			}
+
+			data = append(data, playbyplay)
+		}
+	}
+	return data, nil
+}

--- a/dataprovider/baseballsavantmlb/scraper_play_by_play_test.go
+++ b/dataprovider/baseballsavantmlb/scraper_play_by_play_test.go
@@ -1,0 +1,31 @@
+package baseballsavantmlb
+
+import (
+	"testing"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPlayByPlayScraper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	matchupscraper := NewMatchupScraper(
+		MatchupScraperDate("2024-10-30"),
+	)
+	matchuprunner := sportscrape.NewMatchupRunner(
+		sportscrape.MatchupRunnerScraper(matchupscraper),
+	)
+	matchups, err := matchuprunner.Run()
+	assert.NoError(t, err)
+
+	playbyplayscraper := NewPlayByPlayScraper()
+	playbyplayrunner := sportscrape.NewEventDataRunner(
+		sportscrape.EventDataRunnerScraper(playbyplayscraper),
+		sportscrape.EventDataRunnerConcurrency(1),
+	)
+	plays, err := playbyplayrunner.Run(matchups...)
+	assert.NoError(t, err)
+	assert.Equal(t, 342, len(plays), "342 plays")
+}

--- a/dataprovider/baseballsavantmlb/url.go
+++ b/dataprovider/baseballsavantmlb/url.go
@@ -1,0 +1,29 @@
+package baseballsavantmlb
+
+import (
+	"strconv"
+
+	"github.com/lightning-dabbler/sportscrape/util"
+)
+
+const (
+	URL = "https://baseballsavant.mlb.com"
+)
+
+// ConstructMatchupURL
+// https://baseballsavant.mlb.com/schedule?date=2025-6-24
+func ConstructMatchupURL(date string) (string, error) {
+	timestamp, err := util.DateStrToTime(date)
+	if err != nil {
+		return "", err
+
+	}
+	datestr := timestamp.Format("2006-1-2")
+	return URL + "/schedule?date=" + datestr, nil
+}
+
+// ConstructEventDataURL
+// https://baseballsavant.mlb.com/gf?game_pk=777386
+func ConstructEventDataURL(eventid int64) string {
+	return URL + "/gf?game_pk=" + strconv.FormatInt(eventid, 10)
+}

--- a/dataprovider/basketballreferencenba/scraper_adv_box_score_stats_test.go
+++ b/dataprovider/basketballreferencenba/scraper_adv_box_score_stats_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetAdvBoxScoreStats(t *testing.T) {
+func TestAdvBoxScoreScraper(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}

--- a/dataprovider/basketballreferencenba/scraper_basic_box_score_stats_test.go
+++ b/dataprovider/basketballreferencenba/scraper_basic_box_score_stats_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetFullBasicBoxScoreStats(t *testing.T) {
+func TestBasicBoxScoreScraper(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}
@@ -102,7 +102,7 @@ func TestGetFullBasicBoxScoreStats(t *testing.T) {
 	assert.Equal(t, expectedHomeDNP, numHomeDNP, "Assert number of home players on LA Lakers that did not play")
 }
 
-func TestGetH1BasicBoxScoreStats(t *testing.T) {
+func TestBasicBoxScoreScraper_H1(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}
@@ -232,7 +232,7 @@ func TestGetH1BasicBoxScoreStats(t *testing.T) {
 	assert.True(t, playerToTest["Gabe Vincent"], "Gabe Vincent's stats were collected")
 }
 
-func TestGetQ3BasicBoxScoreStats(t *testing.T) {
+func TestBasicBoxScoreScraper_Q3(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}

--- a/dataprovider/basketballreferencenba/scraper_matchups.go
+++ b/dataprovider/basketballreferencenba/scraper_matchups.go
@@ -100,7 +100,7 @@ func (ms MatchupScraper) Feed() sportscrape.Feed {
 func (ms *MatchupScraper) Scrape() sportscrape.MatchupOutput {
 	var matchups []interface{}
 	output := sportscrape.MatchupOutput{}
-	timestamp, err := sportsreference.DateStrToTime(ms.Date)
+	timestamp, err := util.DateStrToTime(ms.Date)
 	if err != nil {
 		output.Error = err
 		return output

--- a/dataprovider/basketballreferencenba/scraper_matchups_test.go
+++ b/dataprovider/basketballreferencenba/scraper_matchups_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/xitongsys/parquet-go/writer"
 )
 
-func TestGetMatchups(t *testing.T) {
+func TestMatchupScraper(t *testing.T) {
 
 	if testing.Short() {
 		t.Skip("Skipping integration test")

--- a/dataprovider/foxsports/scraper_matchup_test.go
+++ b/dataprovider/foxsports/scraper_matchup_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetNBAMatchup(t *testing.T) {
+func TestMatchupScraper_NBA(t *testing.T) {
 	// https://api.foxsports.com/bifrost/v1/nba/scoreboard/segment/20250406?apikey=jE7yBJVRNAwdDesMgTzTXUUSx1It41Fq
 	if testing.Short() {
 		t.Skip("Skipping integration test")
@@ -54,7 +54,7 @@ func TestGetNBAMatchup(t *testing.T) {
 
 }
 
-func TestGetMLBMatchup(t *testing.T) {
+func TestMatchupScraper_MLB(t *testing.T) {
 	// https://api.foxsports.com/bifrost/v1/mlb/scoreboard/segment/20241018?apikey=jE7yBJVRNAwdDesMgTzTXUUSx1It41Fq
 	if testing.Short() {
 		t.Skip("Skipping integration test")
@@ -97,7 +97,7 @@ func TestGetMLBMatchup(t *testing.T) {
 
 }
 
-func TestGetNFLMatchup(t *testing.T) {
+func TestMatchupScraper_NFL(t *testing.T) {
 	// https://api.foxsports.com/bifrost/v1/nfl/scoreboard/segment/2024-4-2?apikey=jE7yBJVRNAwdDesMgTzTXUUSx1It41Fq
 	if testing.Short() {
 		t.Skip("Skipping integration test")
@@ -139,7 +139,7 @@ func TestGetNFLMatchup(t *testing.T) {
 	assert.Equal(t, true, testMatchup.IsPlayoff)
 }
 
-func TestGetNCAABMatchup(t *testing.T) {
+func TestMatchupScraper_NCAAB(t *testing.T) {
 	// https://api.foxsports.com/bifrost/v1/cbk/scoreboard/segment/20250405?groupId=2&apikey=jE7yBJVRNAwdDesMgTzTXUUSx1It41Fq
 	if testing.Short() {
 		t.Skip("Skipping integration test")

--- a/dataprovider/foxsports/scraper_mlb_probable_starting_pitcher_test.go
+++ b/dataprovider/foxsports/scraper_mlb_probable_starting_pitcher_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMLBProbableStartingPitcher(t *testing.T) {
+func TestMLBProbableStartingPitcherScraper(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test")
 	}

--- a/util/sportsreference/util.go
+++ b/util/sportsreference/util.go
@@ -6,25 +6,6 @@ import (
 	"time"
 )
 
-const (
-	// time parse date template
-	dateLayout = "2006-01-02"
-)
-
-// DateStrToTime takes in a date string in the form 2024-01-25
-//
-// Parameter:
-//   - date: the date string to parse
-//
-// Returns a time.Time{} and nilable error
-func DateStrToTime(date string) (time.Time, error) {
-	dateParse, err := time.Parse(dateLayout, date)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("could not parse '%s': %w", date, err)
-	}
-	return dateParse, nil
-}
-
 // EventDate takes in a date string in the form 2024-01-25
 //
 // Parameter:
@@ -37,7 +18,7 @@ func EventDate(date string) (time.Time, error) {
 		return time.Time{}, fmt.Errorf("An issue arose loading timezone: %w", err)
 	}
 
-	dateParse, err := time.ParseInLocation(dateLayout, date, loc)
+	dateParse, err := time.ParseInLocation(time.DateOnly, date, loc)
 	if err != nil {
 		return time.Time{}, fmt.Errorf("Could not parse '%s': %w", date, err)
 	}

--- a/util/sportsreference/util_test.go
+++ b/util/sportsreference/util_test.go
@@ -9,45 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDateStrToTime(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected time.Time
-		isError  bool
-	}{
-		{
-			name:     "valid date",
-			input:    "2024-01-25",
-			expected: time.Date(2024, 1, 25, 0, 0, 0, 0, time.UTC),
-			isError:  false,
-		},
-		{
-			name:    "invalid date format",
-			input:   "01-25-2024",
-			isError: true,
-		},
-		{
-			name:    "empty string",
-			input:   "",
-			isError: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, err := DateStrToTime(tt.input)
-			if tt.isError {
-				assert.Error(t, err)
-				return
-			}
-
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expected, result)
-		})
-	}
-}
-
 func TestEventDate(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/util/string.go
+++ b/util/string.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 )
 
 // re is the regex compilation of one or more spaces
@@ -81,13 +80,4 @@ func TextToFloat32(str string) (float32, error) {
 		return 0, fmt.Errorf("Could not convert %s to float32: %w", str, err)
 	}
 	return float32(val), nil
-}
-
-// RFC3339ToTime converts a RFC 3339 timestamp string to time.Time
-func RFC3339ToTime(str string) (time.Time, error) {
-	timestamp, err := time.Parse(time.RFC3339, str)
-	if err != nil {
-		return time.Time{}, fmt.Errorf("Could not convert RFC3339 string %s to time.Time: %w", str, err)
-	}
-	return timestamp, nil
 }

--- a/util/string_test.go
+++ b/util/string_test.go
@@ -4,7 +4,6 @@ package util
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -239,38 +238,6 @@ func TestTextToFloat32(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestRFC3339ToTime(t *testing.T) {
-	tests := []struct {
-		name     string
-		isError  bool
-		input    string
-		expected time.Time
-	}{
-		{
-			name:    "exception case",
-			isError: true,
-			input:   time.DateOnly,
-		},
-		{
-			name:     "valid RFC 3339",
-			isError:  false,
-			input:    "2025-02-09T23:30:00Z",
-			expected: time.Date(2025, time.February, 9, 23, 30, 0, 0, time.UTC),
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			timestamp, err := RFC3339ToTime(tt.input)
-			if tt.isError {
-				assert.Error(t, err)
-			} else {
-				assert.Equal(t, tt.expected, timestamp)
 			}
 		})
 	}

--- a/util/time.go
+++ b/util/time.go
@@ -1,6 +1,9 @@
 package util
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 func TimeToDays(t time.Time) int32 {
 	// Get seconds since epoch
@@ -8,4 +11,27 @@ func TimeToDays(t time.Time) int32 {
 
 	// Convert to days (86400 seconds in a day)
 	return int32(seconds / 86400)
+}
+
+// DateStrToTime takes in a date string in the form 2024-01-25
+//
+// Parameter:
+//   - date: the date string to parse
+//
+// Returns a time.Time{} and nilable error
+func DateStrToTime(date string) (time.Time, error) {
+	dateParse, err := time.Parse(time.DateOnly, date)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("could not parse '%s': %w", date, err)
+	}
+	return dateParse, nil
+}
+
+// RFC3339ToTime converts a RFC 3339 timestamp string to time.Time
+func RFC3339ToTime(str string) (time.Time, error) {
+	timestamp, err := time.Parse(time.RFC3339, str)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("Could not convert RFC3339 string %s to time.Time: %w", str, err)
+	}
+	return timestamp, nil
 }

--- a/util/time_test.go
+++ b/util/time_test.go
@@ -1,0 +1,81 @@
+//go:build unit
+
+package util
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDateStrToTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected time.Time
+		isError  bool
+	}{
+		{
+			name:     "valid date",
+			input:    "2024-01-25",
+			expected: time.Date(2024, 1, 25, 0, 0, 0, 0, time.UTC),
+			isError:  false,
+		},
+		{
+			name:    "invalid date format",
+			input:   "01-25-2024",
+			isError: true,
+		},
+		{
+			name:    "empty string",
+			input:   "",
+			isError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := DateStrToTime(tt.input)
+			if tt.isError {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestRFC3339ToTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		isError  bool
+		input    string
+		expected time.Time
+	}{
+		{
+			name:    "exception case",
+			isError: true,
+			input:   time.DateOnly,
+		},
+		{
+			name:     "valid RFC 3339",
+			isError:  false,
+			input:    "2025-02-09T23:30:00Z",
+			expected: time.Date(2025, time.February, 9, 23, 30, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			timestamp, err := RFC3339ToTime(tt.input)
+			if tt.isError {
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, tt.expected, timestamp)
+			}
+		})
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is a manually maintained semver version.
 // This is updated by hand when releasing new versions
-const Version = "v0.11.0"
+const Version = "v0.12.0"


### PR DESCRIPTION
## context
### Added
- Added `MatchupScraper` for baseball savant mlb (#84)
- Added `FieldingBoxScoreScraper`,`BattingBoxScoreScraper`, `PitchingBoxScoreScraper`, and `PlayByPlayScraper` for baseball savant mlb (#86)
### Changed
- Moved `RFC3339ToTime` and `DateStrToTime` to time.go (#84)
- Documentation updates (#84)
- Deprecation warning on baseball reference feed (#87)

Fixes #79