### PR TITLE
Bug: Unmarshal baseball savant mlb matchup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed unmarshalling of baseball savant mlb matchups to handle empty response payload
 
 ## [0.13.2] - 2025-07-17
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fixed unmarshalling of baseball savant mlb matchups to handle empty response payload
+- Fixed unmarshalling of baseball savant mlb matchups to handle empty response payload (#94)
 
 ## [0.13.2] - 2025-07-17
 ### Changed

--- a/dataprovider/baseballsavantmlb/jsonresponse/matchup.go
+++ b/dataprovider/baseballsavantmlb/jsonresponse/matchup.go
@@ -1,5 +1,13 @@
 package jsonresponse
 
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+
+	"github.com/lightning-dabbler/sportscrape"
+)
+
 // https://baseballsavant.mlb.com/schedule?date=2025-6-24
 
 type Matchups struct {
@@ -46,4 +54,24 @@ type Team struct {
 		ID   int64  `json:"id"`       // "id": 694973,
 		Name string `json:"fullName"` // "fullName": "Paul Skenes"
 	} `json:"probablePitcher"`
+}
+
+func (m *Matchups) UnmarshalJSON(b []byte) error {
+
+	if bytes.Equal(b, []byte("[]")) {
+		log.Printf("Empty response payload for %s\n", sportscrape.BaseballReferenceMLBMatchup)
+		return nil
+	}
+
+	type Alias Matchups
+	aux := &struct {
+		*Alias
+	}{
+		Alias: (*Alias)(m),
+	}
+	err := json.Unmarshal(b, aux)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/dataprovider/baseballsavantmlb/scraper_matchups.go
+++ b/dataprovider/baseballsavantmlb/scraper_matchups.go
@@ -82,7 +82,10 @@ func (s MatchupScraper) Scrape() sportscrape.MatchupOutput {
 		output.Error = err
 		return output
 	}
-
+	if len(jsonobj.Schedule.Dates) == 0 {
+		output.Output = matchups
+		return output
+	}
 	for _, game := range jsonobj.Schedule.Dates[0].Games {
 		season, err := util.TextToInt32(game.Season)
 		if err != nil {


### PR DESCRIPTION
## Context
### Fixed
- Fixed unmarshalling of baseball savant mlb matchups to handle empty response payload

### Behavior
```go
package main

import (
	"encoding/json"
	"fmt"
	"log"

	"github.com/lightning-dabbler/sportscrape/dataprovider/baseballsavantmlb"
	"github.com/lightning-dabbler/sportscrape/runner"
)

func main() {
	date := "2019-12-26"
	// define matchup scraper
	matchupScraper := baseballsavantmlb.NewMatchupScraper(
		baseballsavantmlb.MatchupScraperDate(date),
	)
	// define matchup runner
	matchuprunner := runner.NewMatchupRunner(
		runner.MatchupRunnerScraper(matchupScraper),
	)
	// Retrieve matchups
	matchups, err := matchuprunner.Run()
	if err != nil {
		panic(err)
	}
	// Output each matchup as pretty json
	for _, matchup := range matchups {
		jsonBytes, err := json.MarshalIndent(matchup, "", "  ")
		if err != nil {
			log.Fatalf("Error marshaling to JSON: %v\n", err)
		}
		fmt.Println(string(jsonBytes))
	}
}
```
#### Before
```console
Fetching from https://baseballsavant.mlb.com/schedule?date=2019-12-26
panic: json: cannot unmarshal array into Go value of type jsonresponse.Matchups
```
#### After
```console
Fetching from https://baseballsavant.mlb.com/schedule?date=2019-12-26
2025/07/27 18:02:25 Empty response payload for baseball reference mlb matchup
2025/07/27 18:02:25 Scraping of baseball savant mlb matchup with 0 record(s) completed in 288.764083ms
```
