### PR TITLE
Fox sports: wnba matchup and box score feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Added fox sports wnba matchup and box score feeds
+### Changed
+- Modified `NBABoxScoreScraper` to support WNBA extraction
+- `EventDataRunner.Run()` and `MatchupRunner.Run()` now call `Scraper.Init()` for extra validation before execution
+### Documentation
+- Added fox sports WNBA matchup and box score to provider list
 
 ## [0.13.4] - 2025-07-29
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ func main() {
 | https://baseball-reference.com   | MLB    | Pitching box score stats| Full                  |[model](dataprovider/baseballreferencemlb/model/pitching_box_score_stats.go)||✅|
 | https://www.foxsports.com		   | NBA	| Matchup				 | Live, Full			  | [model](dataprovider/foxsports/model/matchup.go)||✅|
 | https://www.foxsports.com		   | NBA	| Box score stats		 | Live, Full			  | [model](dataprovider/foxsports/model/nba_box_score_stats.go)||✅|
+| https://www.foxsports.com		   | WNBA	| Matchup				 | Live, Full			  | [model](dataprovider/foxsports/model/matchup.go)||✅|
+| https://www.foxsports.com		   | WNBA	| Box score stats		 | Live, Full			  | [model](dataprovider/foxsports/model/nba_box_score_stats.go)||✅|
 | https://www.foxsports.com		   | MLB	| Matchup				 | Live, Full			  | [model](dataprovider/foxsports/model/matchup.go)||✅|
 | https://www.foxsports.com		   | MLB	| Batting Box score stats| Live, Full			  | [model](dataprovider/foxsports/model/mlb_batting_box_score_stats.go)||✅|
 | https://www.foxsports.com		   | MLB	| Pitching Box score stats| Live, Full			  | [model](dataprovider/foxsports/model/mlb_pitching_box_score_stats.goo)||✅|

--- a/catalog.go
+++ b/catalog.go
@@ -13,6 +13,8 @@ var (
 	FS                           Provider = "fox sports"
 	FSNBAMatchup                 Feed     = Feed(string(FS) + " nba matchup")
 	FSNBABoxScore                Feed     = Feed(string(FS) + " nba box score")
+	FSWNBAMatchup                Feed     = Feed(string(FS) + " wnba matchup")
+	FSWNBABoxScore               Feed     = Feed(string(FS) + " wnba box score")
 	FSMLBMatchup                 Feed     = Feed(string(FS) + " mlb matchup")
 	FSMLBBattingBoxScore         Feed     = Feed(string(FS) + " mlb batting box score")
 	FSMLBPitchingBoxScore        Feed     = Feed(string(FS) + " mlb pitching box score")

--- a/dataprovider/foxsports/example_test.go
+++ b/dataprovider/foxsports/example_test.go
@@ -34,6 +34,30 @@ func ExampleMatchupScraper_nba() {
 	}
 }
 
+// Example for foxsports.MatchupScraper WNBA
+func ExampleMatchupScraper_wnba() {
+	matchupScraper := foxsports.NewMatchupScraper(
+		foxsports.MatchupScraperLeague(foxsports.WNBA),
+		foxsports.MatchupScraperSegmenter(&foxsports.GeneralSegmenter{Date: "2025-08-07"}),
+	)
+	matchuprunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerScraper(matchupScraper),
+	)
+
+	matchups, err := matchuprunner.Run()
+	if err != nil {
+		panic(err)
+	}
+	// Output each statline as pretty json
+	for _, matchup := range matchups {
+		jsonBytes, err := json.MarshalIndent(matchup, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}
+
 // Example for foxsports.MatchupScraper MLB
 func ExampleMatchupScraper_mlb() {
 	matchupScraper := foxsports.NewMatchupScraper(
@@ -109,8 +133,8 @@ func ExampleMatchupScraper_nfl() {
 	}
 }
 
-// Example for foxsports.NBABoxScoreScraper
-func ExampleNBABoxScoreScraper() {
+// Example for foxsports.NBABoxScoreScraper NBA
+func ExampleNBABoxScoreScraper_nba() {
 	// Get matchups
 	matchupScraper := foxsports.NewMatchupScraper(
 		foxsports.MatchupScraperLeague(foxsports.NBA),
@@ -138,8 +162,54 @@ func ExampleNBABoxScoreScraper() {
 	if err != nil {
 		panic(err)
 	}
+	// Output each statline as pretty json
 	for _, statline := range boxScoreStats {
-		fmt.Printf("%#v\n", statline.(model.NBABoxScoreStats))
+		jsonBytes, err := json.MarshalIndent(statline, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}
+
+// Example for foxsports.NBABoxScoreScraper WNBA
+func ExampleNBABoxScoreScraper_wnba() {
+	// Get matchups
+	matchupScraper := foxsports.NewMatchupScraper(
+		foxsports.MatchupScraperLeague(foxsports.WNBA),
+		foxsports.MatchupScraperSegmenter(&foxsports.GeneralSegmenter{Date: "2025-08-07"}),
+	)
+
+	matchuprunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerScraper(matchupScraper),
+	)
+
+	matchups, err := matchuprunner.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	// Get boxscore data
+	eventdatascraper := foxsports.NewNBABoxScoreScraper(
+		foxsports.NBABoxScoreScraperLeague(foxsports.WNBA),
+	)
+	runner := runner.NewEventDataRunner(
+		runner.EventDataRunnerConcurrency(4),
+		runner.EventDataRunnerScraper(
+			eventdatascraper,
+		),
+	)
+	boxScoreStats, err := runner.Run(matchups...)
+	if err != nil {
+		panic(err)
+	}
+	// Output each statline as pretty json
+	for _, statline := range boxScoreStats {
+		jsonBytes, err := json.MarshalIndent(statline, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
 	}
 }
 

--- a/dataprovider/foxsports/league.go
+++ b/dataprovider/foxsports/league.go
@@ -13,6 +13,7 @@ const (
 	MLB
 	NCAAB
 	NFL
+	WNBA
 )
 
 const (
@@ -32,6 +33,8 @@ func (l League) LeaguePath() string {
 		return "cbk"
 	case NFL:
 		return "nfl"
+	case WNBA:
+		return "wnba"
 	default:
 		return "undefined"
 	}
@@ -39,7 +42,7 @@ func (l League) LeaguePath() string {
 
 func (l League) Undefined() bool {
 	switch l {
-	case NBA, MLB, NCAAB, NFL:
+	case NBA, MLB, NCAAB, NFL, WNBA:
 		return false
 	default:
 		return true
@@ -55,13 +58,7 @@ func (l League) Undefined() bool {
 func (l League) V1MatchupURL(segmentID string) (*url.URL, error) {
 	scoreboardPath := "scoreboard/segment/" + segmentID
 	switch l {
-	case NBA:
-		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), scoreboardPath))
-	case MLB:
-		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), scoreboardPath))
-	case NCAAB:
-		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), scoreboardPath))
-	case NFL:
+	case NBA, MLB, NCAAB, NFL, WNBA:
 		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), scoreboardPath))
 	default:
 		return nil, fmt.Errorf("undefined league: %#v", l)
@@ -77,13 +74,7 @@ func (l League) V1MatchupURL(segmentID string) (*url.URL, error) {
 func (l League) V1EventDataURL(eventID int64) (*url.URL, error) {
 	eventPath := fmt.Sprintf("event/%d/data", eventID)
 	switch l {
-	case NBA:
-		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), eventPath))
-	case MLB:
-		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), eventPath))
-	case NCAAB:
-		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), eventPath))
-	case NFL:
+	case NBA, MLB, NCAAB, NFL, WNBA:
 		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), eventPath))
 	default:
 		return nil, fmt.Errorf("undefined League identified: %#v", l)
@@ -99,13 +90,7 @@ func (l League) V1EventDataURL(eventID int64) (*url.URL, error) {
 func (l League) V1MatchupComparisonURL(eventID int64) (*url.URL, error) {
 	eventPath := fmt.Sprintf("event/%d/matchup", eventID)
 	switch l {
-	case NBA:
-		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), eventPath))
-	case MLB:
-		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), eventPath))
-	case NCAAB:
-		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), eventPath))
-	case NFL:
+	case NBA, MLB, NCAAB, NFL, WNBA:
 		return url.Parse(fmt.Sprintf("%s/%s/%s", BifrostEndpointV1, l.LeaguePath(), eventPath))
 	default:
 		return nil, fmt.Errorf("undefined League identified: %#v", l)
@@ -123,6 +108,8 @@ func (l League) String() string {
 		return "NCAAB"
 	case NFL:
 		return "NFL"
+	case WNBA:
+		return "WNBA"
 	default:
 		return "?"
 	}

--- a/dataprovider/foxsports/scraper_matchup.go
+++ b/dataprovider/foxsports/scraper_matchup.go
@@ -95,6 +95,8 @@ func (s *MatchupScraper) Feed() sportscrape.Feed {
 		return sportscrape.FSNFLMatchup
 	case NCAAB:
 		return sportscrape.FSNCAABMatchup
+	case WNBA:
+		return sportscrape.FSWNBAMatchup
 	}
 	return sportscrape.FSNBAMatchup
 }

--- a/dataprovider/foxsports/scraper_matchup_test.go
+++ b/dataprovider/foxsports/scraper_matchup_test.go
@@ -54,6 +54,49 @@ func TestMatchupScraper_NBA(t *testing.T) {
 
 }
 
+func TestMatchupScraper_WNBA(t *testing.T) {
+	// https://api.foxsports.com/bifrost/v1/wnba/scoreboard/segment/20250502?apikey=jE7yBJVRNAwdDesMgTzTXUUSx1It41Fq
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	matchupScraper := NewMatchupScraper(
+		MatchupScraperLeague(WNBA),
+		MatchupScraperSegmenter(&GeneralSegmenter{Date: "2025-05-02"}),
+	)
+
+	matchuprunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerScraper(matchupScraper),
+	)
+
+	matchups, err := matchuprunner.Run()
+	assert.NoError(t, err)
+
+	n_matchups := len(matchups)
+	assert.Equal(t, 2, n_matchups, "2 events")
+	testMatchup := matchups[1].(model.Matchup)
+	assert.Equal(t, int64(2179), testMatchup.EventID)
+	assert.Equal(t, time.Date(2025, time.May, 3, 1, 0, 0, 0, time.UTC), testMatchup.EventTime) // 2025-04-06T22:00:00Z
+	assert.Equal(t, int32(3), testMatchup.EventStatus)
+	assert.Equal(t, "FINAL", testMatchup.StatusLine)
+	assert.Equal(t, int64(2), testMatchup.HomeTeamID)
+	assert.Equal(t, "CHI", testMatchup.HomeTeamAbbreviation)
+	assert.Equal(t, "Sky", testMatchup.HomeTeamNameLong)
+	assert.Equal(t, "Chicago Sky", testMatchup.HomeTeamNameFull)
+	assert.Equal(t, "1-0", testMatchup.HomeRecord)
+	assert.Equal(t, int32(89), testMatchup.HomeScore)
+	assert.Nil(t, testMatchup.HomeRank)
+	assert.Equal(t, int64(24), testMatchup.AwayTeamID)
+	assert.Equal(t, "BRA", testMatchup.AwayTeamAbbreviation)
+	assert.Equal(t, "Brazil National Team", testMatchup.AwayTeamNameLong)
+	assert.Equal(t, "Brazil National Team", testMatchup.AwayTeamNameFull)
+	assert.Equal(t, "0-1", testMatchup.AwayRecord)
+	assert.Equal(t, int32(62), testMatchup.AwayScore)
+	assert.Nil(t, testMatchup.AwayRank)
+	assert.Equal(t, int64(24), *testMatchup.Loser) // Utah lost
+	assert.Equal(t, false, testMatchup.IsPlayoff)
+
+}
+
 func TestMatchupScraper_MLB(t *testing.T) {
 	// https://api.foxsports.com/bifrost/v1/mlb/scoreboard/segment/20241018?apikey=jE7yBJVRNAwdDesMgTzTXUUSx1It41Fq
 	if testing.Short() {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -61,6 +61,7 @@ func (t *EventDataRunner) Run(matchups ...interface{}) ([]interface{}, error) {
 	if t.Deprecated() {
 		return nil, t.Scraper.Feed().Deprecation()
 	}
+	t.Scraper.Init()
 	start := time.Now().UTC()
 	concurrency := t.Concurrency
 	if concurrency <= 0 {
@@ -162,6 +163,7 @@ func (r *MatchupRunner) Run() ([]interface{}, error) {
 	if r.Deprecated() {
 		return nil, r.Scraper.Feed().Deprecation()
 	}
+	r.Scraper.Init()
 	start := time.Now().UTC()
 	ou := r.Scraper.Scrape()
 	if ou.Error != nil {


### PR DESCRIPTION
## Context
### Added
- Added fox sports wnba matchup and box score feeds
### Changed
- Modified `NBABoxScoreScraper` to support WNBA extraction
- `EventDataRunner.Run()` and `MatchupRunner.Run()` now call `Scraper.Init()` for extra validation before execution
### Documentation
- Added fox sports WNBA matchup and box score to provider list

## Example
```go
package main

import (
	"encoding/json"
	"fmt"
	"log"

	"github.com/lightning-dabbler/sportscrape/dataprovider/foxsports"
	"github.com/lightning-dabbler/sportscrape/runner"
)

func main() {
	// Get matchups
	matchupScraper := foxsports.NewMatchupScraper(
		foxsports.MatchupScraperLeague(foxsports.WNBA),
		foxsports.MatchupScraperSegmenter(&foxsports.GeneralSegmenter{Date: "2025-05-02"}),
	)

	matchuprunner := runner.NewMatchupRunner(
		runner.MatchupRunnerScraper(matchupScraper),
	)

	matchups, err := matchuprunner.Run()
	if err != nil {
		panic(err)
	}

	// Get boxscore data
	eventdatascraper := foxsports.NewNBABoxScoreScraper(
		foxsports.NBABoxScoreScraperLeague(foxsports.WNBA),
	)
	runner := runner.NewEventDataRunner(
		runner.EventDataRunnerConcurrency(4),
		runner.EventDataRunnerScraper(
			eventdatascraper,
		),
	)
	boxScoreStats, err := runner.Run(matchups...)
	if err != nil {
		panic(err)
	}
	// Output each statline as pretty json
	for _, statline := range boxScoreStats {
		jsonBytes, err := json.MarshalIndent(statline, "", "  ")
		if err != nil {
			log.Fatalf("Error marshaling to JSON: %v\n", err)
		}
		fmt.Println(string(jsonBytes))
	}
}

```
