### PR TITLE
Foxsports: Betting odds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Chained errors observed in `EventDataRunner` and `MatchupRunner` (#99)
 ### Fixed
-- foxsports `MLBProbableStartingPitcher.StartingPitcherRecord` and `MLBProbableStartingPitcher.StartingPitcherERA` are now nilable
-- Fixed feed name for `FSMLBProbableStartingPitcher`
+- foxsports `MLBProbableStartingPitcher.StartingPitcherRecord` and `MLBProbableStartingPitcher.StartingPitcherERA` are now nilable (#101)
+- Fixed feed name for `FSMLBProbableStartingPitcher` (#101)
 ### Added
 - Added the following fields to the baseball savant mlb `Matchup` model (#100)
     - VenueID
@@ -25,11 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - AwayTeamDivisionID
     - AwayTeamDivisionName
     - AwayStartingPitcherPitchHand
-- Added foxsports `MLBOddsTotalScraper` and `MLBOddsMoneyLineScraper` betting odds extraction
+- Added foxsports `MLBOddsTotalScraper` and `MLBOddsMoneyLineScraper` betting odds extraction (#101)
 ### Documentation
-- foxsports `MLBProbableStartingPitcher.StartingPitcherRecord` and `MLBProbableStartingPitcher.StartingPitcherERA` are not point-in-time (PIT) with respect to event
+- foxsports `MLBProbableStartingPitcher.StartingPitcherRecord` and `MLBProbableStartingPitcher.StartingPitcherERA` are not point-in-time (PIT) with respect to event (#101)
     - Added comment to data model
-- Added foxsports mlb odds total and model line to catalog in README
+- Added foxsports mlb odds total and model line to catalog in README (#101)
 ## [0.14.0] - 2025-08-08
 ### Added
 - Added fox sports wnba matchup and box score feeds (#97)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Chained errors observed in `EventDataRunner` and `MatchupRunner` (#99)
 ### Fixed
 - foxsports `MLBProbableStartingPitcher.StartingPitcherRecord` and `MLBProbableStartingPitcher.StartingPitcherERA` are now nilable
+- Fixed feed name for `FSMLBProbableStartingPitcher`
 ### Added
 - Added the following fields to the baseball savant mlb `Matchup` model (#100)
     - VenueID
@@ -24,9 +25,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - AwayTeamDivisionID
     - AwayTeamDivisionName
     - AwayStartingPitcherPitchHand
+- Added foxsports `MLBOddsTotalScraper` and `MLBOddsMoneyLineScraper` betting odds extraction
 ### Documentation
 - foxsports `MLBProbableStartingPitcher.StartingPitcherRecord` and `MLBProbableStartingPitcher.StartingPitcherERA` are not point-in-time (PIT) with respect to event
     - Added comment to data model
+- Added foxsports mlb odds total and model line to catalog in README
 ## [0.14.0] - 2025-08-08
 ### Added
 - Added fox sports wnba matchup and box score feeds (#97)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Chained errors observed in `EventDataRunner` and `MatchupRunner` (#99)
+### Fixed
 - foxsports `MLBProbableStartingPitcher.StartingPitcherRecord` and `MLBProbableStartingPitcher.StartingPitcherERA` are now nilable
 ### Added
 - Added the following fields to the baseball savant mlb `Matchup` model (#100)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Chained errors observed in `EventDataRunner` and `MatchupRunner` (#99)
+- foxsports `MLBProbableStartingPitcher.StartingPitcherRecord` and `MLBProbableStartingPitcher.StartingPitcherERA` are now nilable
 ### Added
 - Added the following fields to the baseball savant mlb `Matchup` model (#100)
     - VenueID
@@ -22,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - AwayTeamDivisionID
     - AwayTeamDivisionName
     - AwayStartingPitcherPitchHand
+### Documentation
+- foxsports `MLBProbableStartingPitcher.StartingPitcherRecord` and `MLBProbableStartingPitcher.StartingPitcherERA` are not point-in-time (PIT) with respect to event
+    - Added comment to data model
 ## [0.14.0] - 2025-08-08
 ### Added
 - Added fox sports wnba matchup and box score feeds (#97)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ func main() {
 | https://www.foxsports.com		   | MLB	| Batting Box score stats| Live, Full			  | [model](dataprovider/foxsports/model/mlb_batting_box_score_stats.go)||✅|
 | https://www.foxsports.com		   | MLB	| Pitching Box score stats| Live, Full			  | [model](dataprovider/foxsports/model/mlb_pitching_box_score_stats.goo)||✅|
 | https://www.foxsports.com		   | MLB	| Probable starting pitcher| Full			  | [model](dataprovider/foxsports/model/mlb_probable_starting_pitcher.go)||✅|
+| https://www.foxsports.com		   | MLB	| Betting Odds Money line| Full			  | [model](dataprovider/foxsports/model/mlb_odds_money_line.go)||✅|
+| https://www.foxsports.com		   | MLB	| Betting Odds Total| Full			  | [model](dataprovider/foxsports/model/mlb_odds_total.go)||✅|
 | https://www.foxsports.com		   | NCAAB	| Matchup				 | Live, Full			  | [model](dataprovider/foxsports/model/matchup.go)||✅|
 | https://www.foxsports.com		   | NFL	| Matchup				 | Live, Full			  | [model](dataprovider/foxsports/model/matchup.go)||✅|
 | https://baseballsavant.mlb.com		   | MLB	| Matchup				 | Live, Full			  |[model](dataprovider/baseballsavantmlb/model/matchup.go) ||✅|

--- a/catalog.go
+++ b/catalog.go
@@ -18,7 +18,7 @@ var (
 	FSMLBMatchup                 Feed     = Feed(string(FS) + " mlb matchup")
 	FSMLBBattingBoxScore         Feed     = Feed(string(FS) + " mlb batting box score")
 	FSMLBPitchingBoxScore        Feed     = Feed(string(FS) + " mlb pitching box score")
-	FSMLBProbableStartingPitcher Feed     = Feed(string(FS) + " mlb pitching box score")
+	FSMLBProbableStartingPitcher Feed     = Feed(string(FS) + " mlb probable starting pitcher")
 	FSMLBOddsTotal               Feed     = Feed(string(FS) + " mlb odds total")
 	FSMLBOddsMoneyLine           Feed     = Feed(string(FS) + " mlb odds money line")
 	FSNFLMatchup                 Feed     = Feed(string(FS) + " nfl matchup")

--- a/catalog.go
+++ b/catalog.go
@@ -19,6 +19,8 @@ var (
 	FSMLBBattingBoxScore         Feed     = Feed(string(FS) + " mlb batting box score")
 	FSMLBPitchingBoxScore        Feed     = Feed(string(FS) + " mlb pitching box score")
 	FSMLBProbableStartingPitcher Feed     = Feed(string(FS) + " mlb pitching box score")
+	FSMLBOddsTotal               Feed     = Feed(string(FS) + " mlb odds total")
+	FSMLBOddsMoneyLine           Feed     = Feed(string(FS) + " mlb odds money line")
 	FSNFLMatchup                 Feed     = Feed(string(FS) + " nfl matchup")
 	FSNCAABMatchup               Feed     = Feed(string(FS) + " ncaab matchup")
 

--- a/dataprovider/foxsports/example_test.go
+++ b/dataprovider/foxsports/example_test.go
@@ -326,3 +326,81 @@ func ExampleMLBProbableStartingPitcherScraper() {
 		fmt.Println(string(jsonBytes))
 	}
 }
+
+// Example for foxsports.MLBOddsTotalScraper
+func ExampleMLBOddsTotalScraper() {
+	// Get matchups
+	matchupScraper := foxsports.NewMatchupScraper(
+		foxsports.MatchupScraperLeague(foxsports.MLB),
+		foxsports.MatchupScraperSegmenter(&foxsports.GeneralSegmenter{Date: "2025-08-28"}),
+	)
+
+	matchuprunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerScraper(matchupScraper),
+	)
+
+	matchups, err := matchuprunner.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	// Get starting pitcher data
+	eventdatascraper := foxsports.NewMLBOddsTotalScraper()
+	runner := runner.NewEventDataRunner(
+		runner.EventDataRunnerConcurrency(4),
+		runner.EventDataRunnerScraper(
+			eventdatascraper,
+		),
+	)
+
+	events, err := runner.Run(matchups...)
+	if err != nil {
+		panic(err)
+	}
+	for _, event := range events {
+		jsonBytes, err := json.MarshalIndent(event, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}
+
+// Example for foxsports.MLBOddsMoneyLineScraper
+func ExampleMLBOddsMoneyLineScraper() {
+	// Get matchups
+	matchupScraper := foxsports.NewMatchupScraper(
+		foxsports.MatchupScraperLeague(foxsports.MLB),
+		foxsports.MatchupScraperSegmenter(&foxsports.GeneralSegmenter{Date: "2025-08-28"}),
+	)
+
+	matchuprunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerScraper(matchupScraper),
+	)
+
+	matchups, err := matchuprunner.Run()
+	if err != nil {
+		panic(err)
+	}
+
+	// Get starting pitcher data
+	eventdatascraper := foxsports.NewMLBOddsMoneyLineScraper()
+	runner := runner.NewEventDataRunner(
+		runner.EventDataRunnerConcurrency(4),
+		runner.EventDataRunnerScraper(
+			eventdatascraper,
+		),
+	)
+
+	events, err := runner.Run(matchups...)
+	if err != nil {
+		panic(err)
+	}
+	for _, event := range events {
+		jsonBytes, err := json.MarshalIndent(event, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}

--- a/dataprovider/foxsports/example_test.go
+++ b/dataprovider/foxsports/example_test.go
@@ -319,6 +319,10 @@ func ExampleMLBProbableStartingPitcherScraper() {
 		panic(err)
 	}
 	for _, event := range probablePitchers {
-		fmt.Printf("%#v\n", event.(model.MLBProbableStartingPitcher))
+		jsonBytes, err := json.MarshalIndent(event, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
 	}
 }

--- a/dataprovider/foxsports/jsonresponse/matchup_comparison_mlb.go
+++ b/dataprovider/foxsports/jsonresponse/matchup_comparison_mlb.go
@@ -8,6 +8,22 @@ type MLBMatchupComparison struct {
 		HomePitcher MLBProbableStartingPitcher `json:"rightEntity"`
 		AwayPitcher MLBProbableStartingPitcher `json:"leftEntity"`
 	} `json:"featuredPairing"`
+
+	BetSection *struct {
+		Name string `json:"name"` // "name": "ODDS"
+		Bets []struct {
+			Template string `json:"template"` // "template": "market"
+			Model    struct {
+				Subtitle string `json:"subtitle"` // "subtitle": "RUN LINE" | // "subtitle": "TEAM TO WIN" | // "subtitle": "TOTAL"
+				MainText string `json:"mainText"` // "mainText": "The Rays must win by 2 runs or more to cover the run line"
+				Odds     []struct {
+					Text    string `json:"text"`    // "text": "-108"
+					SubText string `json:"subText"` // "subText": "CLE" | // "subText": "OVER 9"
+					Success *bool  `json:"success"` // "success": true
+				} `json:"odds"`
+			} `json:"model"`
+		} `json:"bets"`
+	} `json:"betSection"`
 }
 
 type MLBProbableStartingPitcher struct {

--- a/dataprovider/foxsports/jsonresponse/matchup_comparison_mlb.go
+++ b/dataprovider/foxsports/jsonresponse/matchup_comparison_mlb.go
@@ -20,8 +20,8 @@ type MLBProbableStartingPitcher struct {
 			} `json:"tokens"`
 		} `json:"layout"`
 	} `json:"entityLink"`
-	Name      string `json:"name"`         // "name": "T. Skubal"
-	Player    string `json:"imageAltText"` // "imageAltText": "Tarik Skubal"
-	StatLine1 string `json:"statLine1"`    // "statLine1": "4-2"
-	StatLine2 string `json:"statLine2"`    // "statLine2": "2.87 ERA"
+	Name      string  `json:"name"`         // "name": "T. Skubal"
+	Player    string  `json:"imageAltText"` // "imageAltText": "Tarik Skubal"
+	StatLine1 *string `json:"statLine1"`    // "statLine1": "4-2"
+	StatLine2 *string `json:"statLine2"`    // "statLine2": "2.87 ERA"
 }

--- a/dataprovider/foxsports/model/mlb_odds_money_line.go
+++ b/dataprovider/foxsports/model/mlb_odds_money_line.go
@@ -1,0 +1,29 @@
+package model
+
+import "time"
+
+// MLBOddsMoneyLine - data model for MLB money line bettings odds
+type MLBOddsMoneyLine struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// PullTimestampParquet is the fetch timestamp (in milliseconds)
+	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// EventID is a unique ID that maps to the matchup e.g. 86833
+	EventID int64 `json:"event_id" parquet:"name=event_id, type=INT64"`
+	// EventTime is the timestamp associated with the matchup
+	EventTime time.Time `json:"event_time"`
+	// EventTimeParquet is the timestamp associated with the matchup (in milliseconds)
+	EventTimeParquet int64 `json:"-" parquet:"name=event_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// HomeTeamID is the home team's ID e.g. 21
+	HomeTeamID int64 `json:"home_team_id" parquet:"name=home_team_id, type=INT64"`
+	// HomeTeamNameFull is the home team's full name e.g. Atlanta Braves
+	HomeTeamNameFull string `json:"home_team_name_full" parquet:"name=home_team_name_full, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// HomeTeamOdds
+	HomeTeamOdds int32 `json:"home_team_odds" parquet:"name=home_team_odds, type=INT32"`
+	// AwayTeamID is the away team's ID e.g. 8
+	AwayTeamID int64 `json:"away_team_id" parquet:"name=away_team_id, type=INT64"`
+	// AwayTeamNameFull is the away team's full name e.g. Los Angeles Angels
+	AwayTeamNameFull string `json:"away_team_name_full" parquet:"name=away_team_name_full, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// AwayTeamOdds
+	AwayTeamOdds int32 `json:"away_team_odds" parquet:"name=away_team_odds, type=INT32"`
+}

--- a/dataprovider/foxsports/model/mlb_odds_total.go
+++ b/dataprovider/foxsports/model/mlb_odds_total.go
@@ -1,0 +1,31 @@
+package model
+
+import "time"
+
+// MLBOddsTotal - data model for MLB total bettings odds
+type MLBOddsTotal struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// PullTimestampParquet is the fetch timestamp (in milliseconds)
+	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// EventID is a unique ID that maps to the matchup e.g. 86833
+	EventID int64 `json:"event_id" parquet:"name=event_id, type=INT64"`
+	// EventTime is the timestamp associated with the matchup
+	EventTime time.Time `json:"event_time"`
+	// EventTimeParquet is the timestamp associated with the matchup (in milliseconds)
+	EventTimeParquet int64 `json:"-" parquet:"name=event_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// HomeTeamID is the home team's ID e.g. 21
+	HomeTeamID int64 `json:"home_team_id" parquet:"name=home_team_id, type=INT64"`
+	// HomeTeamNameFull is the home team's full name e.g. Atlanta Braves
+	HomeTeamNameFull string `json:"home_team_name_full" parquet:"name=home_team_name_full, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// AwayTeamID is the away team's ID e.g. 8
+	AwayTeamID int64 `json:"away_team_id" parquet:"name=away_team_id, type=INT64"`
+	// AwayTeamNameFull is the away team's full name e.g. Los Angeles Angels
+	AwayTeamNameFull string `json:"away_team_name_full" parquet:"name=away_team_name_full, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// OverOdds
+	OverOdds int32 `json:"over_odds" parquet:"name=over_odds, type=INT32"`
+	// UnderOdds
+	UnderOdds int32 `json:"under_odds" parquet:"name=under_odds, type=INT32"`
+	// TotalLine
+	TotalLine float32 `json:"total_line" parquet:"name=total_line, type=FLOAT"`
+}

--- a/dataprovider/foxsports/model/mlb_probable_starting_pitcher.go
+++ b/dataprovider/foxsports/model/mlb_probable_starting_pitcher.go
@@ -23,7 +23,9 @@ type MLBProbableStartingPitcher struct {
 	// StartingPitcher the name of the team's starting pitcher
 	StartingPitcher string `json:"starting_pitcher" parquet:"name=starting_pitcher, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// StartingPitcherRecord is the record of the team's starting pitcher
-	StartingPitcherRecord string `json:"starting_pitcher_record" parquet:"name=starting_pitcher_record, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// Please note: the API does not provide PIT starting pitcher record! This field is not reliable for PIT calculations.
+	StartingPitcherRecord *string `json:"starting_pitcher_record" parquet:"name=starting_pitcher_record, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// StartingPitcherERA is the team's starting pitcher's earned run average - https://www.mlb.com/glossary/standard-stats/earned-run-average
-	StartingPitcherERA float32 `json:"starting_pitcher_era" parquet:"name=starting_pitcher_era, type=FLOAT"`
+	// Please note: the API does not provide PIT starting pitcher ERA! This field is not reliable for PIT calculations.
+	StartingPitcherERA *float32 `json:"starting_pitcher_era" parquet:"name=starting_pitcher_era, type=FLOAT"`
 }

--- a/dataprovider/foxsports/scraper_mlb_odds_money_line.go
+++ b/dataprovider/foxsports/scraper_mlb_odds_money_line.go
@@ -1,0 +1,141 @@
+package foxsports
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/foxsports/jsonresponse"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/foxsports/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	"github.com/xitongsys/parquet-go/types"
+)
+
+const (
+	oddsMoneyLineTitle = "TEAM TO WIN"
+)
+
+// MLBOddsMoneyLineScraperOption defines a configuration option for the scraper
+type MLBOddsMoneyLineScraperOption func(*MLBOddsMoneyLineScraper)
+
+// MLBOddsMoneyLineScraperParams sets the Params option
+func MLBOddsMoneyLineScraperParams(params map[string]string) MLBOddsMoneyLineScraperOption {
+	return func(s *MLBOddsMoneyLineScraper) {
+		s.Params = params
+	}
+}
+
+// NewMLBOddsMoneyLineScraper creates a new MLBOddsMoneyLineScraper with the provided options
+func NewMLBOddsMoneyLineScraper(options ...MLBOddsMoneyLineScraperOption) *MLBOddsMoneyLineScraper {
+	s := &MLBOddsMoneyLineScraper{}
+
+	// Apply all options
+	for _, option := range options {
+		option(s)
+	}
+	s.League = MLB
+	s.Init()
+
+	return s
+}
+
+type MLBOddsMoneyLineScraper struct {
+	EventDataScraper
+}
+
+func (s MLBOddsMoneyLineScraper) Feed() sportscrape.Feed {
+	return sportscrape.FSMLBOddsMoneyLine
+}
+
+func (s *MLBOddsMoneyLineScraper) Scrape(matchup interface{}) sportscrape.EventDataOutput {
+	start := time.Now().UTC()
+	matchupModel := matchup.(model.Matchup)
+	context := s.ConstructContext(matchupModel)
+
+	var data []interface{}
+	// Construct event data URL
+	log.Println("Constructing event data URL")
+	url, err := s.ConstructMatchupComparisonURL(matchupModel.EventID)
+	if err != nil {
+		log.Println("Issue constructing matchup comparison URL")
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	context.URL = url
+	pullTimestamp := time.Now().UTC()
+	// Fetch event data
+	responseBody, err := s.FetchData(url)
+	if err != nil {
+		log.Println("Issue fetching matchup comparison")
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	context.PullTimestamp = pullTimestamp
+	// Unmarshal JSON
+	var responsePayload jsonresponse.MLBMatchupComparison
+	err = json.Unmarshal(responseBody, &responsePayload)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if responsePayload.BetSection == nil {
+		log.Printf("No betting odds data available for event %d\n", matchupModel.EventID)
+		return sportscrape.EventDataOutput{Context: context}
+	}
+	if responsePayload.BetSection.Name != betSectionTitle {
+		err = fmt.Errorf("unknown title '%s'. expected '%s'", responsePayload.BetSection.Name, betSectionTitle)
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+
+	odds, err := s.record(matchupModel, responsePayload, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+
+	if odds != nil {
+		data = append(data, *odds)
+	}
+
+	diff := time.Now().UTC().Sub(start)
+	log.Printf("Scraping of event %d (%s vs %s) completed in %s\n", matchupModel.EventID, matchupModel.AwayTeamNameFull, matchupModel.HomeTeamNameFull, diff)
+	return sportscrape.EventDataOutput{Output: data, Context: context}
+}
+
+func (s *MLBOddsMoneyLineScraper) record(matchupModel model.Matchup, responsePayload jsonresponse.MLBMatchupComparison, context sportscrape.EventDataContext) (*model.MLBOddsMoneyLine, error) {
+	var oddsText string
+	for _, bet := range responsePayload.BetSection.Bets {
+		if bet.Model.Subtitle != oddsMoneyLineTitle {
+			continue
+		}
+		record := &model.MLBOddsMoneyLine{
+			PullTimestamp:        context.PullTimestamp,
+			PullTimestampParquet: types.TimeToTIMESTAMP_MILLIS(context.PullTimestamp, true),
+			EventID:              context.EventID.(int64),
+			EventTime:            context.EventTime,
+			EventTimeParquet:     types.TimeToTIMESTAMP_MILLIS(context.EventTime, true),
+			HomeTeamID:           context.HomeID.(int64),
+			HomeTeamNameFull:     context.HomeTeam,
+			AwayTeamID:           context.AwayID.(int64),
+			AwayTeamNameFull:     context.AwayTeam,
+		}
+		n := len(bet.Model.Odds)
+		if n != 2 {
+			return nil, fmt.Errorf("%d mlb odds money line items identified. expected 2", n)
+		}
+		for _, oddsItem := range bet.Model.Odds {
+			oddsText = oddsItem.Text
+			odds, err := util.TextToInt32(oddsText)
+			if err != nil {
+				return nil, err
+			}
+			if matchupModel.AwayTeamAbbreviation == oddsItem.SubText {
+				record.AwayTeamOdds = odds
+			} else if matchupModel.HomeTeamAbbreviation == oddsItem.SubText {
+				record.HomeTeamOdds = odds
+			} else {
+				return nil, fmt.Errorf("unexpected team abbreviation identifed '%s'. expected %s or %s", oddsItem.SubText, matchupModel.HomeTeamAbbreviation, matchupModel.AwayTeamAbbreviation)
+			}
+		}
+		return record, nil
+	}
+	return nil, nil
+}

--- a/dataprovider/foxsports/scraper_mlb_odds_money_line_test.go
+++ b/dataprovider/foxsports/scraper_mlb_odds_money_line_test.go
@@ -1,0 +1,47 @@
+//go:build integration
+
+package foxsports
+
+import (
+	"testing"
+
+	"github.com/lightning-dabbler/sportscrape/dataprovider/foxsports/model"
+	"github.com/lightning-dabbler/sportscrape/runner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMLBOddsMoneyLineScraper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	// Get matchups
+	matchupScraper := NewMatchupScraper(
+		MatchupScraperLeague(MLB),
+		MatchupScraperSegmenter(&GeneralSegmenter{Date: "2024-10-25"}),
+	)
+
+	matchuprunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerScraper(matchupScraper),
+	)
+
+	matchups, err := matchuprunner.Run()
+	assert.NoError(t, err)
+
+	oddsScraper := NewMLBOddsMoneyLineScraper()
+	oddsrunner := runner.NewEventDataRunner(
+		runner.EventDataRunnerConcurrency(1),
+		runner.EventDataRunnerScraper(
+			oddsScraper,
+		),
+	)
+	odds, err := oddsrunner.Run(matchups...)
+	assert.NoError(t, err)
+	n_records := len(odds)
+	n_expected := 1
+	assert.Equal(t, n_expected, n_records, "1 odds record")
+	record := odds[0].(model.MLBOddsMoneyLine)
+
+	assert.Equal(t, int32(104), record.AwayTeamOdds)
+	assert.Equal(t, int32(-123), record.HomeTeamOdds)
+}

--- a/dataprovider/foxsports/scraper_mlb_odds_total.go
+++ b/dataprovider/foxsports/scraper_mlb_odds_total.go
@@ -1,0 +1,188 @@
+package foxsports
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/foxsports/jsonresponse"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/foxsports/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	"github.com/xitongsys/parquet-go/types"
+)
+
+const (
+	betSectionTitle    = "ODDS"
+	oddsTotalTitle     = "TOTAL"
+	oddsTotalLineRegex = `(?:UNDER|OVER)\s+(\d+(?:\.\d)?)` // e.g "OVER 9"| "UNDER 8.5"
+)
+
+var oddsTotalLineRe = regexp.MustCompile(oddsTotalLineRegex)
+
+// MLBOddsTotalScraperOption defines a configuration option for the scraper
+type MLBOddsTotalScraperOption func(*MLBOddsTotalScraper)
+
+// MLBOddsTotalScraperParams sets the Params option
+func MLBOddsTotalScraperParams(params map[string]string) MLBOddsTotalScraperOption {
+	return func(s *MLBOddsTotalScraper) {
+		s.Params = params
+	}
+}
+
+// NewMLBOddsTotalScraper creates a new MLBOddsTotalScraper with the provided options
+func NewMLBOddsTotalScraper(options ...MLBOddsTotalScraperOption) *MLBOddsTotalScraper {
+	s := &MLBOddsTotalScraper{}
+
+	// Apply all options
+	for _, option := range options {
+		option(s)
+	}
+	s.League = MLB
+	s.Init()
+
+	return s
+}
+
+type MLBOddsTotalScraper struct {
+	EventDataScraper
+}
+
+func (s MLBOddsTotalScraper) Feed() sportscrape.Feed {
+	return sportscrape.FSMLBOddsTotal
+}
+
+func (s *MLBOddsTotalScraper) Scrape(matchup interface{}) sportscrape.EventDataOutput {
+	start := time.Now().UTC()
+	matchupModel := matchup.(model.Matchup)
+	context := s.ConstructContext(matchupModel)
+
+	var data []interface{}
+	// Construct event data URL
+	log.Println("Constructing event data URL")
+	url, err := s.ConstructMatchupComparisonURL(matchupModel.EventID)
+	if err != nil {
+		log.Println("Issue constructing matchup comparison URL")
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	context.URL = url
+	pullTimestamp := time.Now().UTC()
+	// Fetch event data
+	responseBody, err := s.FetchData(url)
+	if err != nil {
+		log.Println("Issue fetching matchup comparison")
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	context.PullTimestamp = pullTimestamp
+	// Unmarshal JSON
+	var responsePayload jsonresponse.MLBMatchupComparison
+	err = json.Unmarshal(responseBody, &responsePayload)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+	if responsePayload.BetSection == nil {
+		log.Printf("No betting odds data available for event %d\n", matchupModel.EventID)
+		return sportscrape.EventDataOutput{Context: context}
+	}
+	if responsePayload.BetSection.Name != betSectionTitle {
+		err = fmt.Errorf("unknown title '%s'. expected '%s'", responsePayload.BetSection.Name, betSectionTitle)
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+
+	odds, err := s.record(matchupModel, responsePayload, context)
+	if err != nil {
+		return sportscrape.EventDataOutput{Error: err, Context: context}
+	}
+
+	if odds != nil {
+		data = append(data, *odds)
+	}
+
+	diff := time.Now().UTC().Sub(start)
+	log.Printf("Scraping of event %d (%s vs %s) completed in %s\n", matchupModel.EventID, matchupModel.AwayTeamNameFull, matchupModel.HomeTeamNameFull, diff)
+	return sportscrape.EventDataOutput{Output: data, Context: context}
+}
+
+func (s *MLBOddsTotalScraper) parseLine(lineText string) (float32, error) {
+	matches := oddsTotalLineRe.FindStringSubmatch(lineText)
+	if len(matches) != 2 {
+		return 0, fmt.Errorf("'%s' does not match odds total line pattern %s", lineText, oddsTotalLineRegex)
+	}
+	line, err := util.TextToFloat32(matches[1])
+	if err != nil {
+		return 0, err
+	}
+	return line, nil
+}
+
+func (s *MLBOddsTotalScraper) record(matchupModel model.Matchup, responsePayload jsonresponse.MLBMatchupComparison, context sportscrape.EventDataContext) (*model.MLBOddsTotal, error) {
+	var lineText, oddsText string
+	var line float32
+	var err error
+	for _, bet := range responsePayload.BetSection.Bets {
+		if bet.Model.Subtitle != oddsTotalTitle {
+			continue
+		}
+		record := &model.MLBOddsTotal{
+			PullTimestamp:        context.PullTimestamp,
+			PullTimestampParquet: types.TimeToTIMESTAMP_MILLIS(context.PullTimestamp, true),
+			EventID:              context.EventID.(int64),
+			EventTime:            context.EventTime,
+			EventTimeParquet:     types.TimeToTIMESTAMP_MILLIS(context.EventTime, true),
+			HomeTeamID:           context.HomeID.(int64),
+			HomeTeamNameFull:     context.HomeTeam,
+			AwayTeamID:           context.AwayID.(int64),
+			AwayTeamNameFull:     context.AwayTeam,
+		}
+		var n int
+		n = len(bet.Model.Odds)
+		if n != 2 {
+			return nil, fmt.Errorf("%d mlb odds total items identified. expected 2", n)
+		}
+		parsedLines := []float32{}
+		for _, oddsItem := range bet.Model.Odds {
+			lineText = oddsItem.SubText
+			oddsText = oddsItem.Text
+			if strings.HasPrefix(lineText, "UNDER") {
+				line, err = s.parseLine(lineText)
+				if err != nil {
+					return nil, err
+				}
+				parsedLines = append(parsedLines, line)
+				odds, err := util.TextToInt32(oddsText)
+				if err != nil {
+					return nil, err
+				}
+				record.UnderOdds = odds
+
+			} else if strings.HasPrefix(lineText, "OVER") {
+				line, err = s.parseLine(lineText)
+				if err != nil {
+					return nil, err
+				}
+				parsedLines = append(parsedLines, line)
+				odds, err := util.TextToInt32(oddsText)
+				if err != nil {
+					return nil, err
+				}
+				record.OverOdds = odds
+
+			} else {
+				return nil, fmt.Errorf("unrecognized prefix in odds total line text %s. expected OVER or UNDER", lineText)
+			}
+		}
+		n = len(parsedLines)
+		if n != 2 {
+			return nil, fmt.Errorf("expected total lines to be parsed twice was instead parsed %d times", n)
+		}
+		if parsedLines[0] != parsedLines[1] {
+			return nil, fmt.Errorf("expected equal line results (%d != %d)", parsedLines[0], parsedLines[1])
+		}
+		record.TotalLine = parsedLines[0]
+		return record, nil
+	}
+	return nil, nil
+}

--- a/dataprovider/foxsports/scraper_mlb_odds_total.go
+++ b/dataprovider/foxsports/scraper_mlb_odds_total.go
@@ -179,7 +179,7 @@ func (s *MLBOddsTotalScraper) record(matchupModel model.Matchup, responsePayload
 			return nil, fmt.Errorf("expected total lines to be parsed twice was instead parsed %d times", n)
 		}
 		if parsedLines[0] != parsedLines[1] {
-			return nil, fmt.Errorf("expected equal line results (%d != %d)", parsedLines[0], parsedLines[1])
+			return nil, fmt.Errorf("expected equal line results (%f != %f)", parsedLines[0], parsedLines[1])
 		}
 		record.TotalLine = parsedLines[0]
 		return record, nil

--- a/dataprovider/foxsports/scraper_mlb_odds_total_test.go
+++ b/dataprovider/foxsports/scraper_mlb_odds_total_test.go
@@ -1,0 +1,48 @@
+//go:build integration
+
+package foxsports
+
+import (
+	"testing"
+
+	"github.com/lightning-dabbler/sportscrape/dataprovider/foxsports/model"
+	"github.com/lightning-dabbler/sportscrape/runner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMLBOddsTotalScraper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+
+	// Get matchups
+	matchupScraper := NewMatchupScraper(
+		MatchupScraperLeague(MLB),
+		MatchupScraperSegmenter(&GeneralSegmenter{Date: "2024-10-25"}),
+	)
+
+	matchuprunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerScraper(matchupScraper),
+	)
+
+	matchups, err := matchuprunner.Run()
+	assert.NoError(t, err)
+
+	oddsScraper := NewMLBOddsTotalScraper()
+	oddsrunner := runner.NewEventDataRunner(
+		runner.EventDataRunnerConcurrency(1),
+		runner.EventDataRunnerScraper(
+			oddsScraper,
+		),
+	)
+	odds, err := oddsrunner.Run(matchups...)
+	assert.NoError(t, err)
+	n_records := len(odds)
+	n_expected := 1
+	assert.Equal(t, n_expected, n_records, "1 odds record")
+	record := odds[0].(model.MLBOddsTotal)
+
+	assert.Equal(t, int32(-101), record.OverOdds)
+	assert.Equal(t, int32(-119), record.UnderOdds)
+	assert.Equal(t, float32(9), record.TotalLine)
+}

--- a/dataprovider/foxsports/scraper_mlb_probable_starting_pitcher.go
+++ b/dataprovider/foxsports/scraper_mlb_probable_starting_pitcher.go
@@ -124,7 +124,8 @@ func (s *MLBProbableStartingPitcherScraper) era(rawStatline string) (float32, er
 }
 
 func (s *MLBProbableStartingPitcherScraper) pitcher(team string, responsePayload jsonresponse.MLBMatchupComparison, context sportscrape.EventDataContext) (*model.MLBProbableStartingPitcher, error) {
-	var name, era, playerid, teamName string
+	var name, playerid, teamName string
+	var era *string
 
 	switch team {
 	case "home":
@@ -172,11 +173,14 @@ func (s *MLBProbableStartingPitcherScraper) pitcher(team string, responsePayload
 		probablePitchers.StartingPitcherID = playerID
 
 		// StartingPitcherERA
-		era, err := s.era(era)
-		if err != nil {
-			return nil, err
+		if era != nil {
+			era, err := s.era(*era)
+			if err != nil {
+				return nil, err
+			}
+			probablePitchers.StartingPitcherERA = &era
 		}
-		probablePitchers.StartingPitcherERA = era
+
 		return probablePitchers, nil
 	}
 

--- a/dataprovider/foxsports/scraper_mlb_probable_starting_pitcher.go
+++ b/dataprovider/foxsports/scraper_mlb_probable_starting_pitcher.go
@@ -15,11 +15,11 @@ import (
 )
 
 const (
-	probablePitcherTitle = "PROBABLE STARTING PITCHERS"
-	regexExpr            = `^(\d+\.\d+)\sERA`
+	probablePitcherTitle    = "PROBABLE STARTING PITCHERS"
+	probablePitcherEraRegex = `^(\d+\.\d+)\sERA`
 )
 
-var re = regexp.MustCompile(regexExpr)
+var probablePitcherEraRe = regexp.MustCompile(probablePitcherEraRegex)
 
 // MLBProbableStartingPitcherScraperOption defines a configuration option for the scraper
 type MLBProbableStartingPitcherScraperOption func(*MLBProbableStartingPitcherScraper)
@@ -112,9 +112,9 @@ func (s *MLBProbableStartingPitcherScraper) Scrape(matchup interface{}) sportscr
 }
 
 func (s *MLBProbableStartingPitcherScraper) era(rawStatline string) (float32, error) {
-	matches := re.FindStringSubmatch(rawStatline)
+	matches := probablePitcherEraRe.FindStringSubmatch(rawStatline)
 	if len(matches) != 2 {
-		return 0, fmt.Errorf("%s does not match ERA pattern %s in featuredPairing", rawStatline, regexExpr)
+		return 0, fmt.Errorf("%s does not match ERA pattern %s in featuredPairing", rawStatline, probablePitcherEraRegex)
 	}
 	era, err := util.TextToFloat32(matches[1])
 	if err != nil {

--- a/dataprovider/foxsports/scraper_mlb_probable_starting_pitcher_test.go
+++ b/dataprovider/foxsports/scraper_mlb_probable_starting_pitcher_test.go
@@ -44,12 +44,12 @@ func TestMLBProbableStartingPitcherScraper(t *testing.T) {
 	awayStartingPitcher := probablePitchers[1].(model.MLBProbableStartingPitcher)
 
 	assert.Equal(t, "Jack Flaherty", homeStartingPitcher.StartingPitcher)
-	assert.Equal(t, "1-2", homeStartingPitcher.StartingPitcherRecord)
-	assert.Equal(t, float32(7.36), homeStartingPitcher.StartingPitcherERA)
+	assert.Equal(t, "1-2", *homeStartingPitcher.StartingPitcherRecord)
+	assert.Equal(t, float32(7.36), *homeStartingPitcher.StartingPitcherERA)
 	assert.Equal(t, int64(8249), homeStartingPitcher.StartingPitcherID)
 
 	assert.Equal(t, "Gerrit Cole", awayStartingPitcher.StartingPitcher)
-	assert.Equal(t, "1-0", awayStartingPitcher.StartingPitcherRecord)
-	assert.Equal(t, float32(2.17), awayStartingPitcher.StartingPitcherERA)
+	assert.Equal(t, "1-0", *awayStartingPitcher.StartingPitcherRecord)
+	assert.Equal(t, float32(2.17), *awayStartingPitcher.StartingPitcherERA)
 	assert.Equal(t, int64(5539), awayStartingPitcher.StartingPitcherID)
 }


### PR DESCRIPTION
## Context
### Fixed
- foxsports `MLBProbableStartingPitcher.StartingPitcherRecord` and `MLBProbableStartingPitcher.StartingPitcherERA` are now nilable
- Fixed feed name for `FSMLBProbableStartingPitcher`
### Added
- Added foxsports `MLBOddsTotalScraper` and `MLBOddsMoneyLineScraper` betting odds extraction
### Documentation
- foxsports `MLBProbableStartingPitcher.StartingPitcherRecord` and `MLBProbableStartingPitcher.StartingPitcherERA` are not point-in-time (PIT) with respect to event
    - Added comment to data model
- Added foxsports mlb odds total and model line to catalog in README