### PR TITLE
fox sports: Bug fix odds total line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
--  foxsports `MLBOddsTotal.OverOdds` and `MLBOddsTotal.UnderOdds` are now optional because it's not always available for all events.
+-  foxsports `MLBOddsTotal.OverOdds` and `MLBOddsTotal.UnderOdds` are now optional because it's not always available for all events (#103)
 ## [0.15.0] - 2025-08-28
 ### Changed
 - Chained errors observed in `EventDataRunner` and `MatchupRunner` (#99)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+### Changed
+-  foxsports `MLBOddsTotal.OverOdds` and `MLBOddsTotal.UnderOdds` are now optional
 ## [0.15.0] - 2025-08-28
 ### Changed
 - Chained errors observed in `EventDataRunner` and `MatchupRunner` (#99)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
--  foxsports `MLBOddsTotal.OverOdds` and `MLBOddsTotal.UnderOdds` are now optional
+### Fixed
+-  foxsports `MLBOddsTotal.OverOdds` and `MLBOddsTotal.UnderOdds` are now optional because it's not always available for all events.
 ## [0.15.0] - 2025-08-28
 ### Changed
 - Chained errors observed in `EventDataRunner` and `MatchupRunner` (#99)

--- a/dataprovider/foxsports/example_test.go
+++ b/dataprovider/foxsports/example_test.go
@@ -344,7 +344,7 @@ func ExampleMLBOddsTotalScraper() {
 		panic(err)
 	}
 
-	// Get starting pitcher data
+	// Get odds total line data
 	eventdatascraper := foxsports.NewMLBOddsTotalScraper()
 	runner := runner.NewEventDataRunner(
 		runner.EventDataRunnerConcurrency(4),
@@ -383,7 +383,7 @@ func ExampleMLBOddsMoneyLineScraper() {
 		panic(err)
 	}
 
-	// Get starting pitcher data
+	// Get odds money line data
 	eventdatascraper := foxsports.NewMLBOddsMoneyLineScraper()
 	runner := runner.NewEventDataRunner(
 		runner.EventDataRunnerConcurrency(4),

--- a/dataprovider/foxsports/jsonresponse/matchup_comparison_mlb.go
+++ b/dataprovider/foxsports/jsonresponse/matchup_comparison_mlb.go
@@ -17,9 +17,9 @@ type MLBMatchupComparison struct {
 				Subtitle string `json:"subtitle"` // "subtitle": "RUN LINE" | // "subtitle": "TEAM TO WIN" | // "subtitle": "TOTAL"
 				MainText string `json:"mainText"` // "mainText": "The Rays must win by 2 runs or more to cover the run line"
 				Odds     []struct {
-					Text    string `json:"text"`    // "text": "-108"
-					SubText string `json:"subText"` // "subText": "CLE" | // "subText": "OVER 9"
-					Success *bool  `json:"success"` // "success": true
+					Text    *string `json:"text"`    // "text": "-108"
+					SubText string  `json:"subText"` // "subText": "CLE" | // "subText": "OVER 9"
+					Success *bool   `json:"success"` // "success": true
 				} `json:"odds"`
 			} `json:"model"`
 		} `json:"bets"`

--- a/dataprovider/foxsports/model/mlb_odds_total.go
+++ b/dataprovider/foxsports/model/mlb_odds_total.go
@@ -23,9 +23,9 @@ type MLBOddsTotal struct {
 	// AwayTeamNameFull is the away team's full name e.g. Los Angeles Angels
 	AwayTeamNameFull string `json:"away_team_name_full" parquet:"name=away_team_name_full, type=BYTE_ARRAY, convertedtype=UTF8"`
 	// OverOdds
-	OverOdds int32 `json:"over_odds" parquet:"name=over_odds, type=INT32"`
+	OverOdds *int32 `json:"over_odds" parquet:"name=over_odds, type=INT32"`
 	// UnderOdds
-	UnderOdds int32 `json:"under_odds" parquet:"name=under_odds, type=INT32"`
+	UnderOdds *int32 `json:"under_odds" parquet:"name=under_odds, type=INT32"`
 	// TotalLine
 	TotalLine float32 `json:"total_line" parquet:"name=total_line, type=FLOAT"`
 }

--- a/dataprovider/foxsports/scraper_mlb_odds_money_line.go
+++ b/dataprovider/foxsports/scraper_mlb_odds_money_line.go
@@ -122,7 +122,7 @@ func (s *MLBOddsMoneyLineScraper) record(matchupModel model.Matchup, responsePay
 			return nil, fmt.Errorf("%d mlb odds money line items identified. expected 2", n)
 		}
 		for _, oddsItem := range bet.Model.Odds {
-			oddsText = oddsItem.Text
+			oddsText = *oddsItem.Text
 			odds, err := util.TextToInt32(oddsText)
 			if err != nil {
 				return nil, err

--- a/dataprovider/foxsports/scraper_mlb_odds_total_test.go
+++ b/dataprovider/foxsports/scraper_mlb_odds_total_test.go
@@ -42,7 +42,7 @@ func TestMLBOddsTotalScraper(t *testing.T) {
 	assert.Equal(t, n_expected, n_records, "1 odds record")
 	record := odds[0].(model.MLBOddsTotal)
 
-	assert.Equal(t, int32(-101), record.OverOdds)
-	assert.Equal(t, int32(-119), record.UnderOdds)
+	assert.Equal(t, int32(-101), *record.OverOdds)
+	assert.Equal(t, int32(-119), *record.UnderOdds)
 	assert.Equal(t, float32(9), record.TotalLine)
 }


### PR DESCRIPTION
## Context
### Fixed
-  foxsports `MLBOddsTotal.OverOdds` and `MLBOddsTotal.UnderOdds` are now optional because it's not always available for all events.

## Example
event date `2024-03-12` has events with nil over and under odds
```go
package main

import (
	"encoding/json"
	"fmt"
	"log"

	"github.com/lightning-dabbler/sportscrape/dataprovider/foxsports"
	"github.com/lightning-dabbler/sportscrape/runner"
)

func main() {
	// Get matchups
	matchupScraper := foxsports.NewMatchupScraper(
		foxsports.MatchupScraperLeague(foxsports.MLB),
		foxsports.MatchupScraperSegmenter(&foxsports.GeneralSegmenter{Date: "2024-03-12"}),
	)

	matchuprunner := runner.NewMatchupRunner(
		runner.MatchupRunnerScraper(matchupScraper),
	)

	matchups, err := matchuprunner.Run()
	if err != nil {
		panic(err)
	}

	// Get starting pitcher data
	eventdatascraper := foxsports.NewMLBOddsTotalScraper()
	runner := runner.NewEventDataRunner(
		runner.EventDataRunnerConcurrency(4),
		runner.EventDataRunnerScraper(
			eventdatascraper,
		),
	)

	events, err := runner.Run(matchups...)
	if err != nil {
		panic(err)
	}
	for _, event := range events {
		jsonBytes, err := json.MarshalIndent(event, "", "  ")
		if err != nil {
			log.Fatalf("Error marshaling to JSON: %v\n", err)
		}
		fmt.Println(string(jsonBytes))
	}
}

```