### PR TITLE
Release/v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Call `Close()` on the matchup scraper when `KeepAlive: true` and `MatchupRunner.Run()` returns an error, in all `example_test.go` files (`dataprovider/nba`, `dataprovider/basketballreferencenba`, `dataprovider/espn/mma`) and all NBA integration test files (#135)
+- Replace bare `assert.NoError(t, err)` after `matchuprunner.Run()` with an explicit `if err != nil` guard that calls `matchupScraper.Close()` then `t.Fatal(err)` in NBA integration tests (`dataprovider/nba/scraper_box_score_*_test.go`, `scraper_play_by_play_test.go`) (#135)
+
+### Documentation
+- Updated Quick start example in README to reflect current NBA provider usage: set `NetworkHeaders`, `KeepAlive: true`, inject `DocumentRetriever` into box score scraper, close on error, and use `nba.Full` period (#135)
 
 ## [1.1.0] - 2026-03-15
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.1] - 2026-03-16
 ### Fixed
 - Call `Close()` on the matchup scraper when `KeepAlive: true` and `MatchupRunner.Run()` returns an error, in all `example_test.go` files (`dataprovider/nba`, `dataprovider/basketballreferencenba`, `dataprovider/espn/mma`) and all NBA integration test files (#135)
 - Replace bare `assert.NoError(t, err)` after `matchuprunner.Run()` with an explicit `if err != nil` guard that calls `matchupScraper.Close()` then `t.Fatal(err)` in NBA integration tests (`dataprovider/nba/scraper_box_score_*_test.go`, `scraper_play_by_play_test.go`) (#135)

--- a/README.md
+++ b/README.md
@@ -63,20 +63,25 @@ func main() {
 		nba.WithMatchupDate("2025-06-05"),
 		nba.WithMatchupTimeout(2*time.Minute),
 	)
+	matchupScraper.NetworkHeaders = nba.NetworkHeaders
 	matchuprunner := runner.NewMatchupRunner(
 		runner.MatchupRunnerConfig[model.Matchup]{
-			Scraper: matchupScraper,
+			Scraper:   matchupScraper,
+			KeepAlive: true,
 		},
 	)
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
 	boxscorescraper := nba.NewBoxScoreTraditionalScraper(
-		nba.WithBoxScoreTraditionalTimeout(2 * time.Minute),
+		nba.WithBoxScoreTraditionalTimeout(2*time.Minute),
+		nba.WithBoxScoreTraditionalPeriod(nba.Full),
 	)
+	boxscorescraper.DocumentRetriever = matchupScraper.DocumentRetriever
 
 	boxscorerunner := runner.NewEventDataRunner(
 		runner.EventDataRunnerConfig[model.Matchup, model.BoxScoreTraditional]{

--- a/dataprovider/basketballreferencenba/example_test.go
+++ b/dataprovider/basketballreferencenba/example_test.go
@@ -56,6 +56,7 @@ func ExampleBasicBoxScoreScraper_full() {
 	)
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupscraper.Close()
 		log.Println(err)
 		return
 	}
@@ -101,6 +102,7 @@ func ExampleBasicBoxScoreScraper_q2() {
 	)
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupscraper.Close()
 		log.Println(err)
 		return
 	}
@@ -146,6 +148,7 @@ func ExampleBasicBoxScoreScraper_h2() {
 	)
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupscraper.Close()
 		log.Println(err)
 		return
 	}
@@ -191,6 +194,7 @@ func ExampleAdvBoxScoreScraper() {
 	)
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupscraper.Close()
 		log.Println(err)
 		return
 	}

--- a/dataprovider/espn/mma/example_test.go
+++ b/dataprovider/espn/mma/example_test.go
@@ -52,11 +52,13 @@ func ExampleESPNMMAFightDetailsScraper() {
 	}
 	matchuprunner := runner.NewMatchupRunner(
 		runner.MatchupRunnerConfig[model.Matchup]{
-			Scraper: matchupscraper,
+			Scraper:   matchupscraper,
+			KeepAlive: true,
 		},
 	)
 	result, err := matchuprunner.Run()
 	if err != nil {
+		matchupscraper.Close()
 		panic(err)
 	}
 

--- a/dataprovider/nba/example_test.go
+++ b/dataprovider/nba/example_test.go
@@ -81,6 +81,7 @@ func ExamplePlayByPlayScraper() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -125,6 +126,7 @@ func ExampleBoxScoreUsageScraper_full() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -170,6 +172,7 @@ func ExampleBoxScoreUsageScraper_h2() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -215,6 +218,7 @@ func ExampleBoxScoreTraditionalScraper_q1() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -260,6 +264,7 @@ func ExampleBoxScoreAdvancedScraper_full() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -305,6 +310,7 @@ func ExampleBoxScoreScoringScraper_h1() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -350,6 +356,7 @@ func ExampleBoxScoreMiscScraper_full() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -395,6 +402,7 @@ func ExampleBoxScoreFourFactorsScraper_full() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -440,6 +448,7 @@ func ExampleBoxScoreLiveScraper() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -484,6 +493,7 @@ func ExampleBoxScoreTrackingScraper() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -528,6 +538,7 @@ func ExampleBoxScoreMatchupsScraper() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -572,6 +583,7 @@ func ExampleBoxScoreDefenseScraper() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 
@@ -616,6 +628,7 @@ func ExampleBoxScoreHustleScraper() {
 
 	matchups, err := matchuprunner.Run()
 	if err != nil {
+		matchupScraper.Close()
 		panic(err)
 	}
 

--- a/dataprovider/nba/scraper_box_score_advanced_test.go
+++ b/dataprovider/nba/scraper_box_score_advanced_test.go
@@ -27,7 +27,10 @@ func TestBoxScoreAdvancedScraper(t *testing.T) {
 		},
 	)
 	matchups, err := matchuprunner.Run()
-	assert.NoError(t, err)
+	if err != nil {
+		matchupScraper.Close()
+		t.Fatal(err)
+	}
 	boxscorescraper := NewBoxScoreAdvancedScraper(
 		WithBoxScoreAdvancedTimeout(3*time.Minute),
 		WithBoxScoreAdvancedPeriod(Full),

--- a/dataprovider/nba/scraper_box_score_defense_test.go
+++ b/dataprovider/nba/scraper_box_score_defense_test.go
@@ -26,7 +26,10 @@ func TestBoxScoreDefenseScraper(t *testing.T) {
 		},
 	)
 	matchups, err := matchuprunner.Run()
-	assert.NoError(t, err)
+	if err != nil {
+		matchupScraper.Close()
+		t.Fatal(err)
+	}
 	boxscorescraper := NewBoxScoreDefenseScraper(
 		WithBoxScoreDefenseTimeout(3 * time.Minute),
 	)

--- a/dataprovider/nba/scraper_box_score_four_factors_test.go
+++ b/dataprovider/nba/scraper_box_score_four_factors_test.go
@@ -27,7 +27,10 @@ func TestBoxScoreFourFactorsScraper(t *testing.T) {
 		},
 	)
 	matchups, err := matchuprunner.Run()
-	assert.NoError(t, err)
+	if err != nil {
+		matchupScraper.Close()
+		t.Fatal(err)
+	}
 	boxscorescraper := NewBoxScoreFourFactorsScraper(
 		WithBoxScoreFourFactorsTimeout(3*time.Minute),
 		WithBoxScoreFourFactorsPeriod(Full),

--- a/dataprovider/nba/scraper_box_score_hustle_test.go
+++ b/dataprovider/nba/scraper_box_score_hustle_test.go
@@ -26,7 +26,10 @@ func TestBoxScoreHustleScraper(t *testing.T) {
 		},
 	)
 	matchups, err := matchuprunner.Run()
-	assert.NoError(t, err)
+	if err != nil {
+		matchupScraper.Close()
+		t.Fatal(err)
+	}
 	boxscorescraper := NewBoxScoreHustleScraper(
 		WithBoxScoreHustleTimeout(3 * time.Minute),
 	)

--- a/dataprovider/nba/scraper_box_score_matchups_test.go
+++ b/dataprovider/nba/scraper_box_score_matchups_test.go
@@ -26,7 +26,10 @@ func TestBoxScoreMatchupsScraper(t *testing.T) {
 		},
 	)
 	matchups, err := matchuprunner.Run()
-	assert.NoError(t, err)
+	if err != nil {
+		matchupScraper.Close()
+		t.Fatal(err)
+	}
 	boxscorescraper := NewBoxScoreMatchupsScraper(
 		WithBoxScoreMatchupsTimeout(3 * time.Minute),
 	)

--- a/dataprovider/nba/scraper_box_score_misc_test.go
+++ b/dataprovider/nba/scraper_box_score_misc_test.go
@@ -27,7 +27,10 @@ func TestBoxScoreMiscScraper(t *testing.T) {
 		},
 	)
 	matchups, err := matchuprunner.Run()
-	assert.NoError(t, err)
+	if err != nil {
+		matchupScraper.Close()
+		t.Fatal(err)
+	}
 	boxscorescraper := NewBoxScoreMiscScraper(
 		WithBoxScoreMiscTimeout(3*time.Minute),
 		WithBoxScoreMiscPeriod(Full),

--- a/dataprovider/nba/scraper_box_score_scoring_test.go
+++ b/dataprovider/nba/scraper_box_score_scoring_test.go
@@ -27,7 +27,10 @@ func TestBoxScoreScoringScraper(t *testing.T) {
 		},
 	)
 	matchups, err := matchuprunner.Run()
-	assert.NoError(t, err)
+	if err != nil {
+		matchupScraper.Close()
+		t.Fatal(err)
+	}
 	boxscorescraper := NewBoxScoreScoringScraper(
 		WithBoxScoreScoringTimeout(3*time.Minute),
 		WithBoxScoreScoringPeriod(H1),

--- a/dataprovider/nba/scraper_box_score_tracking_test.go
+++ b/dataprovider/nba/scraper_box_score_tracking_test.go
@@ -26,7 +26,10 @@ func TestBoxScoreTrackingScraper(t *testing.T) {
 		},
 	)
 	matchups, err := matchuprunner.Run()
-	assert.NoError(t, err)
+	if err != nil {
+		matchupScraper.Close()
+		t.Fatal(err)
+	}
 	boxscorescraper := NewBoxScoreTrackingScraper(
 		WithBoxScoreTrackingTimeout(3 * time.Minute),
 	)

--- a/dataprovider/nba/scraper_box_score_traditional_test.go
+++ b/dataprovider/nba/scraper_box_score_traditional_test.go
@@ -27,7 +27,10 @@ func TestBoxScoreTraditionalScraper(t *testing.T) {
 		},
 	)
 	matchups, err := matchuprunner.Run()
-	assert.NoError(t, err)
+	if err != nil {
+		matchupScraper.Close()
+		t.Fatal(err)
+	}
 	boxscorescraper := NewBoxScoreTraditionalScraper(
 		WithBoxScoreTraditionalTimeout(3*time.Minute),
 		WithBoxScoreTraditionalPeriod(Q1),

--- a/dataprovider/nba/scraper_box_score_usage_test.go
+++ b/dataprovider/nba/scraper_box_score_usage_test.go
@@ -29,7 +29,10 @@ func TestBoxScoreUsageScraper(t *testing.T) {
 		},
 	)
 	matchups, err := matchuprunner.Run()
-	assert.NoError(t, err)
+	if err != nil {
+		matchupScraper.Close()
+		t.Fatal(err)
+	}
 	boxscorescraper := NewBoxScoreUsageScraper(
 		WithBoxScoreUsageTimeout(3*time.Minute),
 		WithBoxScoreUsagePeriod(Full),

--- a/dataprovider/nba/scraper_play_by_play_test.go
+++ b/dataprovider/nba/scraper_play_by_play_test.go
@@ -29,7 +29,10 @@ func TestPlayByPlayScraper(t *testing.T) {
 		},
 	)
 	matchups, err := matchuprunner.Run()
-	assert.NoError(t, err)
+	if err != nil {
+		matchupScraper.Close()
+		t.Fatal(err)
+	}
 	playbyplayscraper := NewPlayByPlayScraper(
 		WithPlayByPlayTimeout(3 * time.Minute),
 	)

--- a/version/version.go
+++ b/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is a manually maintained semver version.
 // This is updated by hand when releasing new versions
-const Version = "v1.1.0"
+const Version = "v1.1.1"


### PR DESCRIPTION
### Fixed
- Call `Close()` on the matchup scraper when `KeepAlive: true` and `MatchupRunner.Run()` returns an error, in all `example_test.go` files (`dataprovider/nba`, `dataprovider/basketballreferencenba`, `dataprovider/espn/mma`) and all NBA integration test files (#135)
- Replace bare `assert.NoError(t, err)` after `matchuprunner.Run()` with an explicit `if err != nil` guard that calls `matchupScraper.Close()` then `t.Fatal(err)` in NBA integration tests (`dataprovider/nba/scraper_box_score_*_test.go`, `scraper_play_by_play_test.go`) (#135)

### Documentation
- Updated Quick start example in README to reflect current NBA provider usage: set `NetworkHeaders`, `KeepAlive: true`, inject `DocumentRetriever` into box score scraper, close on error, and use `nba.Full` period (#135)