### PR TITLE
Fix missing NetworkHeaders on matchup-periods CLI scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Set `NetworkHeaders` on the `matchup-periods` scraper in the CLI NBA feed handler (`cmd/sportscrape/internal/feed/nba.go`); previously `scrapeMatchupPeriods` constructed the scraper inline and never assigned `nba.NetworkHeaders`, causing requests to be sent without the required headers
 
 ## [1.1.1] - 2026-03-16
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Set `NetworkHeaders` on the `matchup-periods` scraper in the CLI NBA feed handler (`cmd/sportscrape/internal/feed/nba.go`); previously `scrapeMatchupPeriods` constructed the scraper inline and never assigned `nba.NetworkHeaders`, causing requests to be sent without the required headers
+- Set `NetworkHeaders` on the `matchup-periods` scraper in the CLI NBA feed handler (`cmd/sportscrape/internal/feed/nba.go`); previously `scrapeMatchupPeriods` constructed the scraper inline and never assigned `nba.NetworkHeaders`, causing requests to be sent without the required headers (#137)
 
 ## [1.1.1] - 2026-03-16
 ### Fixed

--- a/cmd/sportscrape/internal/feed/nba.go
+++ b/cmd/sportscrape/internal/feed/nba.go
@@ -151,12 +151,14 @@ func (e *NBAExtractor) scrapeMatchup(ctx context.Context) error {
 }
 
 func (e *NBAExtractor) scrapeMatchupPeriods(ctx context.Context) error {
+	scraper := nba.NewMatchupPeriodsScraper(
+		nba.WithMatchupPeriodsDate(e.Date),
+		nba.WithMatchupPeriodsTimeout(e.Timeout),
+	)
+	scraper.NetworkHeaders = nba.NetworkHeaders
 	matchups, err := runner.NewMatchupRunner(
 		runner.MatchupRunnerConfig[model.MatchupPeriods]{
-			Scraper: nba.NewMatchupPeriodsScraper(
-				nba.WithMatchupPeriodsDate(e.Date),
-				nba.WithMatchupPeriodsTimeout(e.Timeout),
-			),
+			Scraper: scraper,
 		},
 	).Run()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Set `nba.NetworkHeaders` on the `matchup-periods` scraper in `cmd/sportscrape/internal/feed/nba.go`; previously the scraper was constructed inline and never had `NetworkHeaders` assigned, causing requests to be sent without the required headers
- Updated `[Unreleased]` section in `CHANGELOG.md`

## Test plan
- [x] Run `sportscrape nba --feed matchup-periods` and verify requests include the expected network headers