### PR TITLE
Release/v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.1.2] - 2026-03-21
 ### Fixed
 - Set `NetworkHeaders` on the `matchup-periods` scraper in the CLI NBA feed handler (`cmd/sportscrape/internal/feed/nba.go`); previously `scrapeMatchupPeriods` constructed the scraper inline and never assigned `nba.NetworkHeaders`, causing requests to be sent without the required headers (#137)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Set `NetworkHeaders` on the `matchup-periods` scraper in the CLI NBA feed handler (`cmd/sportscrape/internal/feed/nba.go`); previously `scrapeMatchupPeriods` constructed the scraper inline and never assigned `nba.NetworkHeaders`, causing requests to be sent without the required headers (#137)
 
 ## [1.1.1] - 2026-03-16
 ### Fixed

--- a/cmd/sportscrape/internal/feed/nba.go
+++ b/cmd/sportscrape/internal/feed/nba.go
@@ -151,12 +151,14 @@ func (e *NBAExtractor) scrapeMatchup(ctx context.Context) error {
 }
 
 func (e *NBAExtractor) scrapeMatchupPeriods(ctx context.Context) error {
+	scraper := nba.NewMatchupPeriodsScraper(
+		nba.WithMatchupPeriodsDate(e.Date),
+		nba.WithMatchupPeriodsTimeout(e.Timeout),
+	)
+	scraper.NetworkHeaders = nba.NetworkHeaders
 	matchups, err := runner.NewMatchupRunner(
 		runner.MatchupRunnerConfig[model.MatchupPeriods]{
-			Scraper: nba.NewMatchupPeriodsScraper(
-				nba.WithMatchupPeriodsDate(e.Date),
-				nba.WithMatchupPeriodsTimeout(e.Timeout),
-			),
+			Scraper: scraper,
 		},
 	).Run()
 	if err != nil {

--- a/version/version.go
+++ b/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is a manually maintained semver version.
 // This is updated by hand when releasing new versions
-const Version = "v1.1.1"
+const Version = "v1.1.2"


### PR DESCRIPTION
### Fixed
- Set `NetworkHeaders` on the `matchup-periods` scraper in the CLI NBA feed handler (`cmd/sportscrape/internal/feed/nba.go`); previously `scrapeMatchupPeriods` constructed the scraper inline and never assigned `nba.NetworkHeaders`, causing requests to be sent without the required headers (#137)