### PR TITLE
Fix inverted Loser assignment in baseballsavantmlb matchup scraper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
+- Fixed inverted `Loser` team ID assignment in the `baseballsavantmlb` matchup scraper (`dataprovider/baseballsavantmlb/scraper_matchups.go`); previously the winning team's own ID was assigned to `Loser` instead of the opposing team's ID
 - ESPN MMA (`dataprovider/espn/mma`) matchup and fight details scrapers now retry fetching a page if ESPN serves a bot-check interstitial in place of the real content (detected by the absence of the `window['__espnfitt__']` payload); previously this silently produced 0 records with no error (#140)
 - Fixed a dead pointer-equality check in the ESPN MMA matchup scraper (`data == empty`) that could never trigger, masking JSON unmarshal failures (#140)
 

--- a/dataprovider/baseballsavantmlb/scraper_matchups.go
+++ b/dataprovider/baseballsavantmlb/scraper_matchups.go
@@ -154,10 +154,10 @@ func (s MatchupScraper) Scrape() sportscrape.MatchupOutput[model.Matchup] {
 		}
 
 		if game.Teams.Away.IsWinner != nil && *game.Teams.Away.IsWinner {
-			matchup.Loser = &game.Teams.Away.Team.ID
+			matchup.Loser = &game.Teams.Home.Team.ID
 		}
 		if game.Teams.Home.IsWinner != nil && *game.Teams.Home.IsWinner {
-			matchup.Loser = &game.Teams.Home.Team.ID
+			matchup.Loser = &game.Teams.Away.Team.ID
 		}
 
 		matchups = append(matchups, matchup)

--- a/dataprovider/baseballsavantmlb/scraper_matchups_test.go
+++ b/dataprovider/baseballsavantmlb/scraper_matchups_test.go
@@ -60,7 +60,7 @@ func TestMatchupScraper_NBA(t *testing.T) {
 	assert.Equal(t, int32(1), testMatchup.AwayLosses)
 	assert.Equal(t, int32(8), *testMatchup.AwayScore)
 
-	assert.Equal(t, int64(147), *testMatchup.Loser)
+	assert.Equal(t, int64(114), *testMatchup.Loser)
 	assert.Equal(t, "L", testMatchup.GameType)
 	assert.Equal(t, "AL Championship Series", testMatchup.SeriesDescription)
 	assert.Equal(t, int32(7), testMatchup.GamesInSeries)


### PR DESCRIPTION
## Summary
- Fixed the `Loser` team ID assignment in `dataprovider/baseballsavantmlb/scraper_matchups.go`; the winner/loser check had the assignment backwards, setting `matchup.Loser` to the *winning* team's own ID instead of the opposing (losing) team's ID
- Updated the integration test assertion in `scraper_matchups_test.go` to reflect the corrected value (Guardians, home team id `114`, lost 6-8 to the Yankees on 2024-10-18)
- Updated `[Unreleased]` section in `CHANGELOG.md`