### PR TITLE
Lint via golangci-lint pre-commit hook, bump pinned Actions/tool versions

### DIFF
--- a/.github/actions/download-tools-binary/action.yml
+++ b/.github/actions/download-tools-binary/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Download tools binary
-      uses: actions/download-artifact@v7.0.0
+      uses: actions/download-artifact@v8.0.1
       with:
         name: tools-artifact
         path: bin/

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Install go ${{inputs.go-version}}
-      uses: actions/setup-go@v6.2.0
+      uses: actions/setup-go@v6.5.0
       with:
         go-version: ${{inputs.go-version}}
     - name: Go version

--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -16,7 +16,7 @@ jobs:
       successful_run: ${{steps.output.outputs.successful_run}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
         id: test_run
         run: make all-tests test_timeout=20m
       - name: Archive test output and coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: test-artifacts
           path: |

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -18,7 +18,7 @@ jobs:
       tool_binary_successfully_built: ${{steps.output.outputs.tool_binary_successfully_built}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
       sportscrape_binary_successfully_built: ${{steps.output.outputs.sportscrape_binary_successfully_built}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/validate.yml
 
   approval:
-    if: ${{ needs.validate.outputs.successful_pre_commit_run && needs.validate.outputs.successful_go_lint_run && needs.tests.outputs.successful_run}}
+    if: ${{ needs.validate.outputs.successful_pre_commit_run && needs.tests.outputs.successful_run}}
     needs:
       - tests
       - validate

--- a/.github/workflows/release-branch-validation.yml
+++ b/.github/workflows/release-branch-validation.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/require-bump.yml
+++ b/.github/workflows/require-bump.yml
@@ -17,7 +17,7 @@ jobs:
       is_bumped_already: ${{steps.output.outputs.is_bumped_already}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -21,7 +21,7 @@ jobs:
       successful_tag_release: ${{steps.output.outputs.successful_tag_release}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -21,7 +21,7 @@ jobs:
       - name: Run unit tests
         run: make unit-tests
       - name: Archive unit test output and coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: unit-test-artifacts
           path: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,9 +10,6 @@ on:
       successful_pre_commit_run:
         description: "Indication that pre-commit has succeeded"
         value: ${{ jobs.pre-commit.outputs.successful_pre_commit_run }}
-      successful_go_lint_run:
-        description: "Indication that go linting has succeeded"
-        value: ${{ jobs.go-lint.outputs.successful_go_lint_run }}
 jobs:
   pre-commit:
     name: run pre-commit on all files
@@ -21,17 +18,21 @@ jobs:
       successful_pre_commit_run: ${{steps.output.outputs.successful_pre_commit_run}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6.2.0
+      - name: Install Go
+        uses: ./.github/actions/setup-go
         with:
-          python-version: '3.11'
+          go-version: '1.24.2'
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: '3.13'
       - name: Install pre-commit
         run: |
-          pip install pre-commit
+          pip install pre-commit==4.5.1
       - name: Cache pre-commit hooks
         uses: actions/cache@v5.0.3
         with:
@@ -53,40 +54,4 @@ jobs:
           else
             echo "successful_pre_commit_run=false"
             echo "successful_pre_commit_run=false" >> $GITHUB_OUTPUT
-          fi
-
-  go-lint:
-    name: Lint Go project
-    runs-on: ubuntu-latest
-    outputs:
-      successful_go_lint_run: ${{steps.output.outputs.successful_go_lint_run}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: Install Go
-        uses: ./.github/actions/setup-go
-        with:
-          go-version: '1.24.2'
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
-          golangci-lint --version
-      - name: Run golangci-lint
-        id: golangci_lint
-        run: golangci-lint run
-      - name: outputs
-        id: output
-        if: ${{!cancelled()}}
-        env:
-          WORKFLOW_SUCCESS: "${{ steps.golangci_lint.outcome }}"
-        run: |
-          if [[ "$WORKFLOW_SUCCESS" == "success" ]]; then
-            echo "successful_go_lint_run=true"
-            echo "successful_go_lint_run=true" >> $GITHUB_OUTPUT
-          else
-            echo "successful_go_lint_run=false"
-            echo "successful_go_lint_run=false" >> $GITHUB_OUTPUT
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: check-yaml
         exclude: .*templates/
@@ -17,7 +17,11 @@ repos:
     -   id: detect-aws-credentials
         args: [--allow-missing-credentials]
 -   repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
+    rev: v1.7.10
     hooks:
     -   id: actionlint-docker
         args: [-shellcheck=, -pyflakes=] # ignore shellcheck and pyflake
+-   repo: https://github.com/golangci/golangci-lint
+    rev: v2.12.2
+    hooks:
+    -   id: golangci-lint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,6 @@ repos:
     -   id: actionlint-docker
         args: [-shellcheck=, -pyflakes=] # ignore shellcheck and pyflake
 -   repo: https://github.com/golangci/golangci-lint
-    rev: v2.12.2
+    rev: v2.8.0
     hooks:
     -   id: golangci-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Replaced the separate `go-lint` CI job (curl-installed `golangci-lint` v1.64.5) with a `golangci-lint` pre-commit hook (`github.com/golangci/golangci-lint` rev `v2.12.2`) run as part of the existing `pre-commit` job in `validate.yml`; removes the duplicate Go lint pass and its own CI job/output
+- Replaced the separate `go-lint` CI job (curl-installed `golangci-lint` v1.64.5) with a `golangci-lint` pre-commit hook (`github.com/golangci/golangci-lint` rev `v2.8.0` — the latest release still on `go 1.24.0`, matching this project's `go.mod`; `v2.9.0`+ require Go 1.25) run as part of the existing `pre-commit` job in `validate.yml`; removes the duplicate Go lint pass and its own CI job/output
 - Bumped `pre-commit/pre-commit-hooks` rev `v5.0.0` → `v6.0.0` and `rhysd/actionlint` rev `v1.7.7` → `v1.7.10` in `.pre-commit-config.yaml`
 - Bumped GitHub Actions across all workflows: `actions/checkout` `v6.0.2` → `v7.0.1`, `actions/setup-python` `v6.2.0` → `v7.0.0` (Python 3.11 → 3.13), `actions/setup-go` `v6.2.0` → `v6.5.0`, `actions/upload-artifact` `v4` → `v7.0.1` (`all-tests.yml`, `unit-tests.yml`), `actions/download-artifact` `v7.0.0` → `v8.0.1`
 - Pinned `pre-commit` to `4.5.1` in `validate.yml` (was unpinned)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replaced the separate `go-lint` CI job (curl-installed `golangci-lint` v1.64.5) with a `golangci-lint` pre-commit hook (`github.com/golangci/golangci-lint` rev `v2.12.2`) run as part of the existing `pre-commit` job in `validate.yml`; removes the duplicate Go lint pass and its own CI job/output
+- Bumped `pre-commit/pre-commit-hooks` rev `v5.0.0` → `v6.0.0` and `rhysd/actionlint` rev `v1.7.7` → `v1.7.10` in `.pre-commit-config.yaml`
+- Bumped GitHub Actions across all workflows: `actions/checkout` `v6.0.2` → `v7.0.1`, `actions/setup-python` `v6.2.0` → `v7.0.0` (Python 3.11 → 3.13), `actions/setup-go` `v6.2.0` → `v6.5.0`, `actions/upload-artifact` `v4` → `v7.0.1` (`all-tests.yml`, `unit-tests.yml`), `actions/download-artifact` `v7.0.0` → `v8.0.1`
+- Pinned `pre-commit` to `4.5.1` in `validate.yml` (was unpinned)
+
+### Removed
+- `successful_go_lint_run` output from `validate.yml` and its reference in `deploy.yml`'s approval gate, now redundant with `golangci-lint` running via pre-commit
 
 ## [1.2.0] - 2026-08-05
 ### Fixed


### PR DESCRIPTION
## Summary
- Replaced the standalone `go-lint` CI job with a `golangci-lint` pre-commit hook (`github.com/golangci/golangci-lint` rev `v2.8.0`), run as part of the existing `pre-commit` job. `v2.8.0` is the latest release still on `go 1.24.0`, matching this repo's `go.mod` and pinned CI Go version (`v2.9.0`+ requires Go 1.25)
- Removed the now-redundant `successful_go_lint_run` output from `validate.yml` and its reference in `deploy.yml`'s approval gate
- Bumped `pre-commit/pre-commit-hooks` to `v6.0.0` and `rhysd/actionlint` to `v1.7.10`
- Bumped GitHub Actions: `actions/checkout` → `v7.0.1`, `actions/setup-python` → `v7.0.0` (Python 3.13), `actions/setup-go` → `v6.5.0`, `actions/upload-artifact` → `v7.0.1` (`all-tests.yml`, `unit-tests.yml`), `actions/download-artifact` → `v8.0.1`
- Pinned `pre-commit` to `4.5.1` in `validate.yml`
- Updated `CHANGELOG.md`