### PR TITLE
Release/v1.3.0

### DIFF
--- a/.github/actions/download-tools-binary/action.yml
+++ b/.github/actions/download-tools-binary/action.yml
@@ -5,7 +5,7 @@ runs:
   using: composite
   steps:
     - name: Download tools binary
-      uses: actions/download-artifact@v7.0.0
+      uses: actions/download-artifact@v8.0.1
       with:
         name: tools-artifact
         path: bin/

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Install go ${{inputs.go-version}}
-      uses: actions/setup-go@v6.2.0
+      uses: actions/setup-go@v6.5.0
       with:
         go-version: ${{inputs.go-version}}
     - name: Go version

--- a/.github/workflows/all-tests.yml
+++ b/.github/workflows/all-tests.yml
@@ -16,7 +16,7 @@ jobs:
       successful_run: ${{steps.output.outputs.successful_run}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -30,7 +30,7 @@ jobs:
         id: test_run
         run: make all-tests test_timeout=20m
       - name: Archive test output and coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: test-artifacts
           path: |

--- a/.github/workflows/build-binary.yml
+++ b/.github/workflows/build-binary.yml
@@ -18,7 +18,7 @@ jobs:
       tool_binary_successfully_built: ${{steps.output.outputs.tool_binary_successfully_built}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -60,7 +60,7 @@ jobs:
       sportscrape_binary_successfully_built: ${{steps.output.outputs.sportscrape_binary_successfully_built}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     uses: ./.github/workflows/validate.yml
 
   approval:
-    if: ${{ needs.validate.outputs.successful_pre_commit_run && needs.validate.outputs.successful_go_lint_run && needs.tests.outputs.successful_run}}
+    if: ${{ needs.validate.outputs.successful_pre_commit_run && needs.tests.outputs.successful_run}}
     needs:
       - tests
       - validate

--- a/.github/workflows/release-branch-validation.yml
+++ b/.github/workflows/release-branch-validation.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/require-bump.yml
+++ b/.github/workflows/require-bump.yml
@@ -17,7 +17,7 @@ jobs:
       is_bumped_already: ${{steps.output.outputs.is_bumped_already}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -21,7 +21,7 @@ jobs:
       successful_tag_release: ${{steps.output.outputs.successful_tag_release}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -21,7 +21,7 @@ jobs:
       - name: Run unit tests
         run: make unit-tests
       - name: Archive unit test output and coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: unit-test-artifacts
           path: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,9 +10,6 @@ on:
       successful_pre_commit_run:
         description: "Indication that pre-commit has succeeded"
         value: ${{ jobs.pre-commit.outputs.successful_pre_commit_run }}
-      successful_go_lint_run:
-        description: "Indication that go linting has succeeded"
-        value: ${{ jobs.go-lint.outputs.successful_go_lint_run }}
 jobs:
   pre-commit:
     name: run pre-commit on all files
@@ -21,17 +18,21 @@ jobs:
       successful_pre_commit_run: ${{steps.output.outputs.successful_pre_commit_run}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v6.2.0
+      - name: Install Go
+        uses: ./.github/actions/setup-go
         with:
-          python-version: '3.11'
+          go-version: '1.24.2'
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7.0.0
+        with:
+          python-version: '3.13'
       - name: Install pre-commit
         run: |
-          pip install pre-commit
+          pip install pre-commit==4.5.1
       - name: Cache pre-commit hooks
         uses: actions/cache@v5.0.3
         with:
@@ -53,40 +54,4 @@ jobs:
           else
             echo "successful_pre_commit_run=false"
             echo "successful_pre_commit_run=false" >> $GITHUB_OUTPUT
-          fi
-
-  go-lint:
-    name: Lint Go project
-    runs-on: ubuntu-latest
-    outputs:
-      successful_go_lint_run: ${{steps.output.outputs.successful_go_lint_run}}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 0
-      - name: Install Go
-        uses: ./.github/actions/setup-go
-        with:
-          go-version: '1.24.2'
-      - name: Install golangci-lint
-        run: |
-          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.64.5
-          golangci-lint --version
-      - name: Run golangci-lint
-        id: golangci_lint
-        run: golangci-lint run
-      - name: outputs
-        id: output
-        if: ${{!cancelled()}}
-        env:
-          WORKFLOW_SUCCESS: "${{ steps.golangci_lint.outcome }}"
-        run: |
-          if [[ "$WORKFLOW_SUCCESS" == "success" ]]; then
-            echo "successful_go_lint_run=true"
-            echo "successful_go_lint_run=true" >> $GITHUB_OUTPUT
-          else
-            echo "successful_go_lint_run=false"
-            echo "successful_go_lint_run=false" >> $GITHUB_OUTPUT
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
     -   id: check-yaml
         exclude: .*templates/
@@ -17,7 +17,11 @@ repos:
     -   id: detect-aws-credentials
         args: [--allow-missing-credentials]
 -   repo: https://github.com/rhysd/actionlint
-    rev: v1.7.7
+    rev: v1.7.10
     hooks:
     -   id: actionlint-docker
         args: [-shellcheck=, -pyflakes=] # ignore shellcheck and pyflake
+-   repo: https://github.com/golangci/golangci-lint
+    rev: v2.8.0
+    hooks:
+    -   id: golangci-lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.0] - 2026-08-05
+## [1.3.0] - 2026-08-06
 ### Added
 - `propfinder` data provider (`dataprovider/propfinder/mlb`) — MLB weather-by-game data from `api.propfinder.app`, flattening each game's hourly weather readings into one row per reading (composite key: `event_id`, `ballpark_id`, `weather_data_date_time`). Wired into the CLI as `sportscrape propfinder mlb --feed weather`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.3.0] - 2026-08-05
 ### Added
 - `propfinder` data provider (`dataprovider/propfinder/mlb`) — MLB weather-by-game data from `api.propfinder.app`, flattening each game's hourly weather readings into one row per reading (composite key: `event_id`, `ballpark_id`, `weather_data_date_time`). Wired into the CLI as `sportscrape propfinder mlb --feed weather`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - 2026-08-06
 ### Added
-- `propfinder` data provider (`dataprovider/propfinder/mlb`) — MLB weather-by-game data from `api.propfinder.app`, flattening each game's hourly weather readings into one row per reading (composite key: `event_id`, `ballpark_id`, `weather_data_date_time`). Wired into the CLI as `sportscrape propfinder mlb --feed weather`
+- `propfinder` data provider (`dataprovider/propfinder/mlb`) — MLB weather-by-game data from `api.propfinder.app`, flattening each game's hourly weather readings into one row per reading (composite key: `event_id`, `ballpark_id`, `weather_data_date_time`). Wired into the CLI as `sportscrape propfinder mlb --feed weather` (#143)
 
 ### Changed
-- Replaced the separate `go-lint` CI job (curl-installed `golangci-lint` v1.64.5) with a `golangci-lint` pre-commit hook (`github.com/golangci/golangci-lint` rev `v2.8.0` — the latest release still on `go 1.24.0`, matching this project's `go.mod`; `v2.9.0`+ require Go 1.25) run as part of the existing `pre-commit` job in `validate.yml`; removes the duplicate Go lint pass and its own CI job/output
-- Bumped `pre-commit/pre-commit-hooks` rev `v5.0.0` → `v6.0.0` and `rhysd/actionlint` rev `v1.7.7` → `v1.7.10` in `.pre-commit-config.yaml`
-- Bumped GitHub Actions across all workflows: `actions/checkout` `v6.0.2` → `v7.0.1`, `actions/setup-python` `v6.2.0` → `v7.0.0` (Python 3.11 → 3.13), `actions/setup-go` `v6.2.0` → `v6.5.0`, `actions/upload-artifact` `v4` → `v7.0.1` (`all-tests.yml`, `unit-tests.yml`), `actions/download-artifact` `v7.0.0` → `v8.0.1`
-- Pinned `pre-commit` to `4.5.1` in `validate.yml` (was unpinned)
+- Replaced the separate `go-lint` CI job (curl-installed `golangci-lint` v1.64.5) with a `golangci-lint` pre-commit hook (`github.com/golangci/golangci-lint` rev `v2.8.0` — the latest release still on `go 1.24.0`, matching this project's `go.mod`; `v2.9.0`+ require Go 1.25) run as part of the existing `pre-commit` job in `validate.yml`; removes the duplicate Go lint pass and its own CI job/output (#142)
+- Bumped `pre-commit/pre-commit-hooks` rev `v5.0.0` → `v6.0.0` and `rhysd/actionlint` rev `v1.7.7` → `v1.7.10` in `.pre-commit-config.yaml` (#142)
+- Bumped GitHub Actions across all workflows: `actions/checkout` `v6.0.2` → `v7.0.1`, `actions/setup-python` `v6.2.0` → `v7.0.0` (Python 3.11 → 3.13), `actions/setup-go` `v6.2.0` → `v6.5.0`, `actions/upload-artifact` `v4` → `v7.0.1` (`all-tests.yml`, `unit-tests.yml`), `actions/download-artifact` `v7.0.0` → `v8.0.1` (#142)
+- Pinned `pre-commit` to `4.5.1` in `validate.yml` (was unpinned) (#142)
 
 ### Removed
-- `successful_go_lint_run` output from `validate.yml` and its reference in `deploy.yml`'s approval gate, now redundant with `golangci-lint` running via pre-commit
+- `successful_go_lint_run` output from `validate.yml` and its reference in `deploy.yml`'s approval gate, now redundant with `golangci-lint` running via pre-commit (#142)
 
 ## [1.2.0] - 2026-08-05
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `propfinder` data provider (`dataprovider/propfinder/mlb`) — MLB weather-by-game data from `api.propfinder.app`, flattening each game's hourly weather readings into one row per reading (composite key: `event_id`, `ballpark_id`, `weather_data_date_time`). Wired into the CLI as `sportscrape propfinder mlb --feed weather`
+
 ### Changed
 - Replaced the separate `go-lint` CI job (curl-installed `golangci-lint` v1.64.5) with a `golangci-lint` pre-commit hook (`github.com/golangci/golangci-lint` rev `v2.8.0` — the latest release still on `go 1.24.0`, matching this project's `go.mod`; `v2.9.0`+ require Go 1.25) run as part of the existing `pre-commit` job in `validate.yml`; removes the duplicate Go lint pass and its own CI job/output
 - Bumped `pre-commit/pre-commit-hooks` rev `v5.0.0` → `v6.0.0` and `rhysd/actionlint` rev `v1.7.7` → `v1.7.10` in `.pre-commit-config.yaml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Replaced the separate `go-lint` CI job (curl-installed `golangci-lint` v1.64.5) with a `golangci-lint` pre-commit hook (`github.com/golangci/golangci-lint` rev `v2.8.0` — the latest release still on `go 1.24.0`, matching this project's `go.mod`; `v2.9.0`+ require Go 1.25) run as part of the existing `pre-commit` job in `validate.yml`; removes the duplicate Go lint pass and its own CI job/output
+- Bumped `pre-commit/pre-commit-hooks` rev `v5.0.0` → `v6.0.0` and `rhysd/actionlint` rev `v1.7.7` → `v1.7.10` in `.pre-commit-config.yaml`
+- Bumped GitHub Actions across all workflows: `actions/checkout` `v6.0.2` → `v7.0.1`, `actions/setup-python` `v6.2.0` → `v7.0.0` (Python 3.11 → 3.13), `actions/setup-go` `v6.2.0` → `v6.5.0`, `actions/upload-artifact` `v4` → `v7.0.1` (`all-tests.yml`, `unit-tests.yml`), `actions/download-artifact` `v7.0.0` → `v8.0.1`
+- Pinned `pre-commit` to `4.5.1` in `validate.yml` (was unpinned)
+
+### Removed
+- `successful_go_lint_run` output from `validate.yml` and its reference in `deploy.yml`'s approval gate, now redundant with `golangci-lint` running via pre-commit
 
 ## [1.2.0] - 2026-08-05
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 A Go package for collecting and transforming sports statistics from various sources into standardized formats.
 
 [![Deploy][sportscrape-ci-status]][sportscrape-ci]
-[![Go Report Card][go-report-status]][go-report]
 [![Go Reference][goref-sportscrape-status]][goref-sportscrape]
 [![Releases][release-status]][releases]
 
@@ -203,5 +202,3 @@ MIT
 [goref-sportscrape-status]: https://pkg.go.dev/badge/github.com/lightning-dabbler/sportscrape.svg
 [release-status]: https://img.shields.io/github/v/release/lightning-dabbler/sportscrape?display_name=tag&sort=semver (Latest Release)
 [releases]: https://github.com/lightning-dabbler/sportscrape/releases (Releases)
-[go-report]: https://goreportcard.com/report/github.com/lightning-dabbler/sportscrape (Go report)
-[go-report-status]: https://goreportcard.com/badge/github.com/lightning-dabbler/sportscrape (Go report Badge)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ go install github.com/lightning-dabbler/sportscrape/cmd/sportscrape@latest
 | Command | Subcommand | Provider |
 |---------|------------|----------|
 | `sportscrape baseballsavant` | | baseballsavant.mlb.com |
+| `sportscrape propfinder` | `mlb` | api.propfinder.app |
 | `sportscrape foxsports` | `mlb`, `nba`, `wnba` | foxsports.com |
 | `sportscrape espn` | `ufc` | espn.com/mma |
 | `sportscrape nba` | | nba.com |
@@ -111,6 +112,7 @@ func main() {
 - [baseball-reference.com MLB scrape examples](dataprovider/baseballreferencemlb/example_test.go) (Deprecated)
 - [foxsports.com scraping examples](dataprovider/foxsports/example_test.go)
 - [baseballsavant.mlb.com scraping examples](dataprovider/baseballsavantmlb/example_test.go)
+- [propfinder scraping examples](dataprovider/propfinder/mlb/example_test.go)
 - [ESPN MMA scraping examples](dataprovider/espn/mma/example_test.go)
 - [nba.com NBA scraping examples](dataprovider/nba/example_test.go)
 
@@ -141,6 +143,7 @@ func main() {
 | https://baseballsavant.mlb.com		 | MLB	     | Pitching box score stats             |        Live, Full			         |     [model](dataprovider/baseballsavantmlb/model/pitching_box_score.go)      ||✅|
 | https://baseballsavant.mlb.com		 | MLB	     | Fielding box score stats             |        Live, Full			         |     [model](dataprovider/baseballsavantmlb/model/fielding_box_score.go)      ||✅|
 | https://baseballsavant.mlb.com		 | MLB	     | Play by play                         |        Live, Full			         |        [model](dataprovider/baseballsavantmlb/model/play_by_play.go)         ||✅|
+| https://api.propfinder.app		     | MLB	     | Weather				                          |             Full			         |              [model](dataprovider/propfinder/mlb/model/weather.go)               ||✅|
 | https://www.espn.com/mma/     		 | UFC	 | Matchups (Event Details)             |           Full			            |               [model](dataprovider/espn/mma/model/matchup.go)                ||✅|
 | https://www.espn.com/mma/     		 | PFL	 | Matchups (Event Details)             |           Full			            |               [model](dataprovider/espn/mma/model/matchup.go)                | 🚩 |✅|
 | https://www.espn.com/mma/     		 | UFC	 | Fight details (Stats, Odds, Results) |           Full			            |             [model](dataprovider/espn/mma/model/fightdetails.go)             ||✅|

--- a/catalog.go
+++ b/catalog.go
@@ -115,6 +115,10 @@ var (
 	NBATrackingBoxScore      Feed     = Feed(string(NBA) + " tracking box score")
 	NBAPlayByPlay            Feed     = Feed(string(NBA) + " play by play")
 
+	// prop finder
+	PropFinder           Provider = "prop finder"
+	PropFinderMLBWeather Feed     = Feed(string(PropFinder) + " mlb weather")
+
 	// testing
 	DummyProvider Provider = "dummy provider"
 	DummyFeed     Feed     = Feed(string(DummyProvider) + " dummy feed")

--- a/cmd/sportscrape/internal/cli/propfinder.go
+++ b/cmd/sportscrape/internal/cli/propfinder.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/lightning-dabbler/sportscrape/cmd/sportscrape/internal/feed"
+	"github.com/lightning-dabbler/sportscrape/cmd/sportscrape/internal/shared"
+
+	"github.com/spf13/cobra"
+)
+
+func createPropFinderMLBCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "mlb",
+		Short: "Extract MLB data",
+		Long:  "Extract MLB data",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return shared.Run(cmd, "propfinder", "mlb")
+		},
+	}
+	cmd.Flags().IntP("concurrency", "c", 1, fmt.Sprintf("Max number of concurrent goroutines. Dependent on data feed (%s)", feed.PropFinderMLBOptions))
+	cmd.Flags().String("feed", "", fmt.Sprintf("The data feed to extract. Options: %s", feed.PropFinderMLBOptions))
+	shared.EmbedDateFlag(cmd)
+	shared.EmbedDestinationFlag(cmd)
+	shared.EmbedFileFormatFlag(cmd)
+	shared.EmbedParquetFlags(cmd)
+	shared.EmbedS3Flags(cmd)
+	return cmd
+}
+
+func CreatePropFinderCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "propfinder",
+		Aliases: []string{"pf"},
+		Short:   "Extract prop finder data",
+		Long:    "Extract prop finder data",
+	}
+	// Store subcommands (mlb)
+	cmd.AddCommand(createPropFinderMLBCmd())
+	return cmd
+}

--- a/cmd/sportscrape/internal/cli/propfinder_test.go
+++ b/cmd/sportscrape/internal/cli/propfinder_test.go
@@ -1,0 +1,90 @@
+//go:build unit
+
+package cli
+
+import (
+	"testing"
+)
+
+func TestCreatePropFinderCmd(t *testing.T) {
+	cmd := CreatePropFinderCmd()
+
+	t.Run("command metadata", func(t *testing.T) {
+		if cmd.Use != "propfinder" {
+			t.Errorf("Use = %q, want %q", cmd.Use, "propfinder")
+		}
+		if len(cmd.Aliases) == 0 {
+			t.Error("expected aliases to be set")
+		}
+	})
+
+	t.Run("subcommands", func(t *testing.T) {
+		subcommands := map[string]bool{}
+		for _, sub := range cmd.Commands() {
+			subcommands[sub.Use] = true
+		}
+		for _, expected := range []string{"mlb"} {
+			if !subcommands[expected] {
+				t.Errorf("expected subcommand %q to be registered", expected)
+			}
+		}
+	})
+}
+
+func TestCreatePropFinderMLBCmd(t *testing.T) {
+	cmd := createPropFinderMLBCmd()
+
+	t.Run("command metadata", func(t *testing.T) {
+		if cmd.Use != "mlb" {
+			t.Errorf("Use = %q, want %q", cmd.Use, "mlb")
+		}
+	})
+
+	t.Run("required flags exist", func(t *testing.T) {
+		flags := []string{
+			"feed",
+			"date",
+			"concurrency",
+			"destination",
+			"file-format",
+			"parquet-compression",
+			"parquet-row-group-size",
+			"parquet-page-size",
+			"parquet-write-parallelism",
+			"aws-region",
+			"aws-endpoint",
+		}
+		for _, flag := range flags {
+			if cmd.Flags().Lookup(flag) == nil {
+				t.Errorf("expected flag --%s to be registered", flag)
+			}
+		}
+	})
+
+	t.Run("flag defaults", func(t *testing.T) {
+		cases := []struct {
+			flag string
+			want string
+		}{
+			{"concurrency", "1"},
+			{"file-format", "jsonl"},
+			{"parquet-compression", "SNAPPY"},
+			{"parquet-row-group-size", "134217728"}, // 128*1024*1024
+			{"parquet-page-size", "8192"},           // 8*1024
+			{"parquet-write-parallelism", "1"},
+			{"aws-region", "us-east-1"},
+			{"aws-endpoint", ""},
+			{"destination", ""},
+			{"date", ""},
+			{"feed", ""},
+		}
+		for _, tc := range cases {
+			t.Run(tc.flag, func(t *testing.T) {
+				got := cmd.Flags().Lookup(tc.flag).DefValue
+				if got != tc.want {
+					t.Errorf("flag --%s default = %q, want %q", tc.flag, got, tc.want)
+				}
+			})
+		}
+	})
+}

--- a/cmd/sportscrape/internal/feed/propfinder.go
+++ b/cmd/sportscrape/internal/feed/propfinder.go
@@ -1,0 +1,62 @@
+package feed
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lightning-dabbler/sportscrape/cmd/sportscrape/internal/exporters"
+
+	"github.com/lightning-dabbler/sportscrape/dataprovider/propfinder/mlb"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/propfinder/mlb/model"
+	"github.com/lightning-dabbler/sportscrape/runner"
+)
+
+var (
+	PropFinderMLBOptions string = "'weather'"
+	ErrPropFinderMLB     error  = fmt.Errorf("valid options: %s", PropFinderMLBOptions)
+)
+
+type PropFinderExtractor struct {
+	Feed           string
+	Date           string
+	OutputPath     string
+	Format         string
+	S3Config       exporters.S3Config
+	ParquetOptions []exporters.ParquetConfigOption
+}
+
+func (e *PropFinderExtractor) ValidateFeed() error {
+	if err := exporters.ValidateFormat(e.Format); err != nil {
+		return err
+	}
+	switch e.Feed {
+	case "mlb-weather":
+		return nil
+	default:
+		return fmt.Errorf("unsupported feed %q for prop finder. %w", e.Feed, ErrPropFinderMLB)
+	}
+}
+
+func (e *PropFinderExtractor) Scrape(ctx context.Context) error {
+	switch e.Feed {
+	case "mlb-weather":
+		return e.scrapeMLBWeather(ctx)
+	default:
+		return fmt.Errorf("unsupported feed %q for prop finder. %w", e.Feed, ErrPropFinderMLB)
+	}
+}
+
+func (e *PropFinderExtractor) scrapeMLBWeather(ctx context.Context) error {
+	weatherrunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerConfig[model.Weather]{
+			Scraper: mlb.NewWeatherScraper(
+				mlb.WeatherScraperDate(e.Date),
+			),
+		},
+	)
+	m, err := weatherrunner.Run()
+	if err != nil {
+		return err
+	}
+	return exporters.BuildAndWrite(ctx, e.OutputPath, e.Format, e.S3Config, m, e.ParquetOptions...)
+}

--- a/cmd/sportscrape/internal/feed/propfinder_test.go
+++ b/cmd/sportscrape/internal/feed/propfinder_test.go
@@ -1,0 +1,40 @@
+//go:build unit
+
+package feed
+
+import (
+	"testing"
+)
+
+func TestPropFinderExtractorValidateFeed(t *testing.T) {
+	tests := []struct {
+		name    string
+		feed    string
+		format  string
+		wantErr bool
+	}{
+		// valid feeds
+		{name: "mlb-weather jsonl", feed: "mlb-weather", format: "jsonl"},
+		{name: "mlb-weather parquet", feed: "mlb-weather", format: "parquet"},
+		// invalid feed
+		{name: "unsupported feed", feed: "mlb-invalid", format: "jsonl", wantErr: true},
+		// invalid format
+		{name: "unsupported format", feed: "mlb-weather", format: "csv", wantErr: true},
+		// empty
+		{name: "empty feed", feed: "", format: "jsonl", wantErr: true},
+		{name: "empty format", feed: "mlb-weather", format: "", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &PropFinderExtractor{
+				Feed:   tt.feed,
+				Format: tt.format,
+			}
+			err := e.ValidateFeed()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateFeed() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/sportscrape/internal/shared/cli.go
+++ b/cmd/sportscrape/internal/shared/cli.go
@@ -189,6 +189,15 @@ func Run(cmd *cobra.Command, provider, league string) error {
 			S3Config:       s3config,
 			ParquetOptions: parquetOptions,
 		}
+	case "propfinder":
+		e = &feed.PropFinderExtractor{
+			Feed:           feedstring,
+			Date:           date,
+			OutputPath:     destination,
+			Format:         fileFormat,
+			S3Config:       s3config,
+			ParquetOptions: parquetOptions,
+		}
 	case "espn":
 		e = &feed.ESPNMMAExtractor{
 			Feed:              feedstring,

--- a/cmd/sportscrape/main.go
+++ b/cmd/sportscrape/main.go
@@ -54,10 +54,11 @@ func main() {
 		},
 	}
 	embedLoggerFlag(rootCmd)
-	// Store subcommands (foxsports, baseballsavant, espn, nba)
+	// Store subcommands (foxsports, baseballsavant, propfinder, espn, nba)
 	rootCmd.AddCommand(
 		cli.CreateFSCmd(),
 		cli.CreateBaseballSavantCmd(),
+		cli.CreatePropFinderCmd(),
 		cli.CreateESPNCmd(),
 		cli.CreateNBACmd(),
 	)

--- a/dataprovider/propfinder/mlb/example_test.go
+++ b/dataprovider/propfinder/mlb/example_test.go
@@ -1,0 +1,36 @@
+package mlb_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/lightning-dabbler/sportscrape/dataprovider/propfinder/mlb"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/propfinder/mlb/model"
+	"github.com/lightning-dabbler/sportscrape/runner"
+)
+
+// Example for mlb.WeatherScraper
+func ExampleWeatherScraper() {
+	date := "2026-07-30"
+	weatherscraper := mlb.NewWeatherScraper(
+		mlb.WeatherScraperDate(date),
+	)
+	weatherrunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerConfig[model.Weather]{
+			Scraper: weatherscraper,
+		},
+	)
+	weather, err := weatherrunner.Run()
+	if err != nil {
+		panic(err)
+	}
+	// Output each hourly weather reading as pretty json
+	for _, w := range weather {
+		jsonBytes, err := json.MarshalIndent(w, "", "  ")
+		if err != nil {
+			log.Fatalf("Error marshaling to JSON: %v\n", err)
+		}
+		fmt.Println(string(jsonBytes))
+	}
+}

--- a/dataprovider/propfinder/mlb/jsonresponse/weather.go
+++ b/dataprovider/propfinder/mlb/jsonresponse/weather.go
@@ -1,0 +1,72 @@
+package jsonresponse
+
+// Games is the top-level response shape for GET /mlb/weather-games?date=YYYY-MM-DD
+// (a plain JSON array; the endpoint returns "[]" on days with no games).
+type Games []Game
+
+type Team struct {
+	ID       int64  `json:"id"`
+	Code     string `json:"code"`
+	FullName string `json:"fullName"`
+}
+
+type Ballpark struct {
+	ID        int64   `json:"id"`
+	Name      string  `json:"name"`
+	Latitude  float32 `json:"latitude"`
+	Longitude float32 `json:"longitude"`
+	// AzimuthAngle and Elevation are nillable: null for some ballparks
+	AzimuthAngle *float32 `json:"azimuthAngle"`
+	Elevation    *int32   `json:"elevation"`
+	Capacity     int32    `json:"capacity"`
+	TurfType     string   `json:"turfType"`
+	RoofType     string   `json:"roofType"`
+	LeftLine     int32    `json:"leftLine"`
+	// Left and Right are nillable: null for some ballparks
+	Left              *int32 `json:"left"`
+	LeftCenter        int32  `json:"leftCenter"`
+	Center            int32  `json:"center"`
+	RightCenter       int32  `json:"rightCenter"`
+	Right             *int32 `json:"right"`
+	RightLine         int32  `json:"rightLine"`
+	FenceHeightLeft   int32  `json:"fenceHeightLeft"`
+	FenceHeightCenter int32  `json:"fenceHeightCenter"`
+	FenceHeightRight  int32  `json:"fenceHeightRight"`
+	Active            bool   `json:"active"`
+	// Season is a string in the API response (e.g. "2026")
+	Season string `json:"season"`
+}
+
+type WeatherEntry struct {
+	// DateTimeEpoch is a Unix timestamp (seconds)
+	DateTimeEpoch int64   `json:"dateTimeEpoch"`
+	Temp          float32 `json:"temp"`
+	FeelsLike     float32 `json:"feelsLike"`
+	Humidity      float32 `json:"humidity"`
+	Dew           float32 `json:"dew"`
+	Precip        float32 `json:"precip"`
+	PrecipProb    float32 `json:"precipProb"`
+	Snow          float32 `json:"snow"`
+	SnowDepth     float32 `json:"snowDepth"`
+	// WindGust is nillable: observed null at least once in the wild
+	WindGust       *float32 `json:"windGust"`
+	WindSpeed      float32  `json:"windSpeed"`
+	WindDir        float32  `json:"windDir"`
+	Pressure       float32  `json:"pressure"`
+	Visibility     float32  `json:"visibility"`
+	CloudCover     float32  `json:"cloudCover"`
+	SolarRadiation float32  `json:"solarRadiation"`
+	SolarEnergy    float32  `json:"solarEnergy"`
+	UVIndex        float32  `json:"uvIndex"`
+	SevereRisk     float32  `json:"severeRisk"`
+	Conditions     string   `json:"conditions"`
+}
+
+type Game struct {
+	ID          int64          `json:"id"`
+	GameDate    string         `json:"gameDate"`
+	HomeTeam    Team           `json:"homeTeam"`
+	VisitorTeam Team           `json:"visitorTeam"`
+	Ballpark    Ballpark       `json:"ballpark"`
+	WeatherData []WeatherEntry `json:"weatherData"`
+}

--- a/dataprovider/propfinder/mlb/model/weather.go
+++ b/dataprovider/propfinder/mlb/model/weather.go
@@ -1,0 +1,113 @@
+package model
+
+import "time"
+
+// Weather - composite key: event_id, ballpark_id, weather_data_date_time
+type Weather struct {
+	// PullTimestamp is the fetch timestamp for when the request was made to the API
+	PullTimestamp time.Time `json:"pull_timestamp"`
+	// PullTimestampParquet is the fetch timestamp (in milliseconds)
+	PullTimestampParquet int64 `json:"-" parquet:"name=pull_timestamp, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// EventID is a unique ID that maps to the game
+	EventID int64 `json:"event_id" parquet:"name=event_id, type=INT64"`
+	// EventTime is the timestamp associated with the game
+	EventTime time.Time `json:"event_time"`
+	// EventTimeParquet is the timestamp associated with the game (in milliseconds)
+	EventTimeParquet int64 `json:"-" parquet:"name=event_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// HomeTeamID is the home team's ID
+	HomeTeamID int64 `json:"home_team_id" parquet:"name=home_team_id, type=INT64"`
+	// HomeTeamAbbreviation is the abbreviation of the home team's name e.g. TB
+	HomeTeamAbbreviation string `json:"home_team_abbreviation" parquet:"name=home_team_abbreviation, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// HomeTeam is the home team's full name e.g. Tampa Bay Rays
+	HomeTeam string `json:"home_team" parquet:"name=home_team, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// AwayTeamID is the away team's ID
+	AwayTeamID int64 `json:"away_team_id" parquet:"name=away_team_id, type=INT64"`
+	// AwayTeamAbbreviation is the abbreviation of the away team's name e.g. TEX
+	AwayTeamAbbreviation string `json:"away_team_abbreviation" parquet:"name=away_team_abbreviation, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// AwayTeam is the away team's full name e.g. Texas Rangers
+	AwayTeam string `json:"away_team" parquet:"name=away_team, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// BallparkID is the ballpark's ID
+	BallparkID int64 `json:"ballpark_id" parquet:"name=ballpark_id, type=INT64"`
+	// BallparkName e.g. Tropicana Field
+	BallparkName string `json:"ballpark_name" parquet:"name=ballpark_name, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// BallparkLatitude
+	BallparkLatitude float32 `json:"ballpark_latitude" parquet:"name=ballpark_latitude, type=FLOAT"`
+	// BallparkLongitude
+	BallparkLongitude float32 `json:"ballpark_longitude" parquet:"name=ballpark_longitude, type=FLOAT"`
+	// BallparkAzimuthAngle is the ballpark's home plate azimuth angle in degrees (nillable: not available for all ballparks)
+	BallparkAzimuthAngle *float32 `json:"ballpark_azimuth_angle" parquet:"name=ballpark_azimuth_angle, type=FLOAT"`
+	// BallparkElevation in feet (nillable: not available for all ballparks)
+	BallparkElevation *int32 `json:"ballpark_elevation" parquet:"name=ballpark_elevation, type=INT32"`
+	// BallparkCapacity
+	BallparkCapacity int32 `json:"ballpark_capacity" parquet:"name=ballpark_capacity, type=INT32"`
+	// BallparkTurfType e.g. Artificial Turf, Grass
+	BallparkTurfType string `json:"ballpark_turf_type" parquet:"name=ballpark_turf_type, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// BallparkRoofType e.g. Dome, Open, Retractable
+	BallparkRoofType string `json:"ballpark_roof_type" parquet:"name=ballpark_roof_type, type=BYTE_ARRAY, convertedtype=UTF8"`
+	// BallparkLeftLine distance in feet
+	BallparkLeftLine int32 `json:"ballpark_left_line" parquet:"name=ballpark_left_line, type=INT32"`
+	// BallparkLeft distance in feet (nillable: not available for all ballparks)
+	BallparkLeft *int32 `json:"ballpark_left" parquet:"name=ballpark_left, type=INT32"`
+	// BallparkLeftCenter distance in feet
+	BallparkLeftCenter int32 `json:"ballpark_left_center" parquet:"name=ballpark_left_center, type=INT32"`
+	// BallparkCenter distance in feet
+	BallparkCenter int32 `json:"ballpark_center" parquet:"name=ballpark_center, type=INT32"`
+	// BallparkRightCenter distance in feet
+	BallparkRightCenter int32 `json:"ballpark_right_center" parquet:"name=ballpark_right_center, type=INT32"`
+	// BallparkRight distance in feet (nillable: not available for all ballparks)
+	BallparkRight *int32 `json:"ballpark_right" parquet:"name=ballpark_right, type=INT32"`
+	// BallparkRightLine distance in feet
+	BallparkRightLine int32 `json:"ballpark_right_line" parquet:"name=ballpark_right_line, type=INT32"`
+	// BallparkFenceHeightLeft in feet
+	BallparkFenceHeightLeft int32 `json:"ballpark_fence_height_left" parquet:"name=ballpark_fence_height_left, type=INT32"`
+	// BallparkFenceHeightCenter in feet
+	BallparkFenceHeightCenter int32 `json:"ballpark_fence_height_center" parquet:"name=ballpark_fence_height_center, type=INT32"`
+	// BallparkFenceHeightRight in feet
+	BallparkFenceHeightRight int32 `json:"ballpark_fence_height_right" parquet:"name=ballpark_fence_height_right, type=INT32"`
+	// BallparkActive indicates whether the ballpark is currently in use
+	BallparkActive bool `json:"ballpark_active" parquet:"name=ballpark_active, type=BOOLEAN"`
+	// BallparkSeason - e.g. 2026
+	BallparkSeason int32 `json:"ballpark_season" parquet:"name=ballpark_season, type=INT32"`
+	// WeatherDataDateTime is the timestamp of this hourly weather reading
+	WeatherDataDateTime time.Time `json:"weather_data_date_time"`
+	// WeatherDataDateTimeParquet is the timestamp of this hourly weather reading (in milliseconds)
+	WeatherDataDateTimeParquet int64 `json:"-" parquet:"name=weather_data_date_time, type=INT64, logicaltype=TIMESTAMP, logicaltype.unit=MILLIS, logicaltype.isadjustedtoutc=true, convertedtype=TIMESTAMP_MILLIS"`
+	// WeatherDataTemp in degrees Fahrenheit
+	WeatherDataTemp float32 `json:"weather_data_temp" parquet:"name=weather_data_temp, type=FLOAT"`
+	// WeatherDataFeelsLike in degrees Fahrenheit
+	WeatherDataFeelsLike float32 `json:"weather_data_feels_like" parquet:"name=weather_data_feels_like, type=FLOAT"`
+	// WeatherDataHumidity as a percentage
+	WeatherDataHumidity float32 `json:"weather_data_humidity" parquet:"name=weather_data_humidity, type=FLOAT"`
+	// WeatherDataDew point in degrees Fahrenheit
+	WeatherDataDew float32 `json:"weather_data_dew" parquet:"name=weather_data_dew, type=FLOAT"`
+	// WeatherDataPrecipitation amount
+	WeatherDataPrecipitation float32 `json:"weather_data_precipitation" parquet:"name=weather_data_precipitation, type=FLOAT"`
+	// WeatherDataPrecipitationProbability as a percentage
+	WeatherDataPrecipitationProbability float32 `json:"weather_data_precipitation_probability" parquet:"name=weather_data_precipitation_probability, type=FLOAT"`
+	// WeatherDataSnow amount
+	WeatherDataSnow float32 `json:"weather_data_snow" parquet:"name=weather_data_snow, type=FLOAT"`
+	// WeatherDataSnowDepth
+	WeatherDataSnowDepth float32 `json:"weather_data_snow_depth" parquet:"name=weather_data_snow_depth, type=FLOAT"`
+	// WeatherDataWindGust (nillable: observed null at least once in the wild)
+	WeatherDataWindGust *float32 `json:"weather_data_wind_gust" parquet:"name=weather_data_wind_gust, type=FLOAT"`
+	// WeatherDataWindSpeed
+	WeatherDataWindSpeed float32 `json:"weather_data_wind_speed" parquet:"name=weather_data_wind_speed, type=FLOAT"`
+	// WeatherDataWindDir in degrees
+	WeatherDataWindDir float32 `json:"weather_data_wind_dir" parquet:"name=weather_data_wind_dir, type=FLOAT"`
+	// WeatherDataPressure
+	WeatherDataPressure float32 `json:"weather_data_pressure" parquet:"name=weather_data_pressure, type=FLOAT"`
+	// WeatherDataVisibility
+	WeatherDataVisibility float32 `json:"weather_data_visibility" parquet:"name=weather_data_visibility, type=FLOAT"`
+	// WeatherDataCloudCover as a percentage
+	WeatherDataCloudCover float32 `json:"weather_data_cloud_cover" parquet:"name=weather_data_cloud_cover, type=FLOAT"`
+	// WeatherDataSolarRadiation
+	WeatherDataSolarRadiation float32 `json:"weather_data_solar_radiation" parquet:"name=weather_data_solar_radiation, type=FLOAT"`
+	// WeatherDataSolarEnergy
+	WeatherDataSolarEnergy float32 `json:"weather_data_solar_energy" parquet:"name=weather_data_solar_energy, type=FLOAT"`
+	// WeatherDataUVIndex
+	WeatherDataUVIndex float32 `json:"weather_data_uv_index" parquet:"name=weather_data_uv_index, type=FLOAT"`
+	// WeatherDataSevereRisk as a percentage
+	WeatherDataSevereRisk float32 `json:"weather_data_severe_risk" parquet:"name=weather_data_severe_risk, type=FLOAT"`
+	// WeatherDataConditions e.g. Partially cloudy
+	WeatherDataConditions string `json:"weather_data_conditions" parquet:"name=weather_data_conditions, type=BYTE_ARRAY, convertedtype=UTF8"`
+}

--- a/dataprovider/propfinder/mlb/scraper_weather.go
+++ b/dataprovider/propfinder/mlb/scraper_weather.go
@@ -1,0 +1,170 @@
+package mlb
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/propfinder/mlb/jsonresponse"
+	"github.com/lightning-dabbler/sportscrape/dataprovider/propfinder/mlb/model"
+	"github.com/lightning-dabbler/sportscrape/util"
+	"github.com/lightning-dabbler/sportscrape/util/request"
+	"github.com/xitongsys/parquet-go/types"
+)
+
+// WeatherScraperOption defines a configuration option for the scraper
+type WeatherScraperOption func(*WeatherScraper)
+
+// WeatherScraperDate sets the date option
+func WeatherScraperDate(date string) WeatherScraperOption {
+	return func(s *WeatherScraper) {
+		s.Date = date
+	}
+}
+
+// NewWeatherScraper creates a new WeatherScraper with the provided options
+func NewWeatherScraper(options ...WeatherScraperOption) *WeatherScraper {
+	s := &WeatherScraper{}
+
+	// Apply all options
+	for _, option := range options {
+		option(s)
+	}
+
+	return s
+}
+
+type WeatherScraper struct {
+	Date string
+}
+
+func (s WeatherScraper) Init() {
+	if s.Date == "" {
+		log.Fatalln("Date is a required argument")
+	}
+}
+
+func (s WeatherScraper) Provider() sportscrape.Provider {
+	return sportscrape.PropFinder
+}
+
+func (s WeatherScraper) Feed() sportscrape.Feed {
+	return sportscrape.PropFinderMLBWeather
+}
+
+func (s WeatherScraper) Scrape() sportscrape.MatchupOutput[model.Weather] {
+	var weather []model.Weather
+	output := sportscrape.MatchupOutput[model.Weather]{}
+
+	url, err := ConstructWeatherURL(s.Date)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+
+	pullTimestamp := time.Now().UTC()
+	response, err := request.Get(url)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+	defer func() { _ = response.Body.Close() }()
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+	var games jsonresponse.Games
+	err = json.Unmarshal(body, &games)
+	if err != nil {
+		output.Error = err
+		return output
+	}
+
+	for _, game := range games {
+		eventTime, err := util.RFC3339ToTime(game.GameDate)
+		if err != nil {
+			log.Printf("error parsing GameDate: %s", game.GameDate)
+			output.Error = err
+			return output
+		}
+		ballparkSeason, err := util.TextToInt32(game.Ballpark.Season)
+		if err != nil {
+			log.Printf("error converting ballpark season from string to int32: %s", game.Ballpark.Season)
+			output.Error = err
+			return output
+		}
+
+		base := model.Weather{
+			PullTimestamp:        pullTimestamp,
+			PullTimestampParquet: types.TimeToTIMESTAMP_MILLIS(pullTimestamp, true),
+			EventID:              game.ID,
+			EventTime:            eventTime,
+			EventTimeParquet:     types.TimeToTIMESTAMP_MILLIS(eventTime, true),
+
+			HomeTeamID:           game.HomeTeam.ID,
+			HomeTeamAbbreviation: game.HomeTeam.Code,
+			HomeTeam:             game.HomeTeam.FullName,
+			AwayTeamID:           game.VisitorTeam.ID,
+			AwayTeamAbbreviation: game.VisitorTeam.Code,
+			AwayTeam:             game.VisitorTeam.FullName,
+
+			BallparkID:                game.Ballpark.ID,
+			BallparkName:              game.Ballpark.Name,
+			BallparkLatitude:          game.Ballpark.Latitude,
+			BallparkLongitude:         game.Ballpark.Longitude,
+			BallparkAzimuthAngle:      game.Ballpark.AzimuthAngle,
+			BallparkElevation:         game.Ballpark.Elevation,
+			BallparkCapacity:          game.Ballpark.Capacity,
+			BallparkTurfType:          game.Ballpark.TurfType,
+			BallparkRoofType:          game.Ballpark.RoofType,
+			BallparkLeftLine:          game.Ballpark.LeftLine,
+			BallparkLeft:              game.Ballpark.Left,
+			BallparkLeftCenter:        game.Ballpark.LeftCenter,
+			BallparkCenter:            game.Ballpark.Center,
+			BallparkRightCenter:       game.Ballpark.RightCenter,
+			BallparkRight:             game.Ballpark.Right,
+			BallparkRightLine:         game.Ballpark.RightLine,
+			BallparkFenceHeightLeft:   game.Ballpark.FenceHeightLeft,
+			BallparkFenceHeightCenter: game.Ballpark.FenceHeightCenter,
+			BallparkFenceHeightRight:  game.Ballpark.FenceHeightRight,
+			BallparkActive:            game.Ballpark.Active,
+			BallparkSeason:            ballparkSeason,
+		}
+
+		for _, wd := range game.WeatherData {
+			weatherDataDateTime := time.Unix(wd.DateTimeEpoch, 0).UTC()
+			record := base
+			record.WeatherDataDateTime = weatherDataDateTime
+			record.WeatherDataDateTimeParquet = types.TimeToTIMESTAMP_MILLIS(weatherDataDateTime, true)
+			record.WeatherDataTemp = wd.Temp
+			record.WeatherDataFeelsLike = wd.FeelsLike
+			record.WeatherDataHumidity = wd.Humidity
+			record.WeatherDataDew = wd.Dew
+			record.WeatherDataPrecipitation = wd.Precip
+			record.WeatherDataPrecipitationProbability = wd.PrecipProb
+			record.WeatherDataSnow = wd.Snow
+			record.WeatherDataSnowDepth = wd.SnowDepth
+			record.WeatherDataWindGust = wd.WindGust
+			record.WeatherDataWindSpeed = wd.WindSpeed
+			record.WeatherDataWindDir = wd.WindDir
+			record.WeatherDataPressure = wd.Pressure
+			record.WeatherDataVisibility = wd.Visibility
+			record.WeatherDataCloudCover = wd.CloudCover
+			record.WeatherDataSolarRadiation = wd.SolarRadiation
+			record.WeatherDataSolarEnergy = wd.SolarEnergy
+			record.WeatherDataUVIndex = wd.UVIndex
+			record.WeatherDataSevereRisk = wd.SevereRisk
+			record.WeatherDataConditions = wd.Conditions
+
+			weather = append(weather, record)
+		}
+	}
+
+	output.Output = weather
+	return output
+}
+
+func (s WeatherScraper) Close() {}

--- a/dataprovider/propfinder/mlb/scraper_weather_test.go
+++ b/dataprovider/propfinder/mlb/scraper_weather_test.go
@@ -1,0 +1,206 @@
+//go:build integration
+
+package mlb
+
+import (
+	"testing"
+	"time"
+
+	"github.com/lightning-dabbler/sportscrape/dataprovider/propfinder/mlb/model"
+	"github.com/lightning-dabbler/sportscrape/runner"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWeatherScraper(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	weatherscraper := NewWeatherScraper(
+		WeatherScraperDate("2026-07-30"),
+	)
+	weatherrunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerConfig[model.Weather]{
+			Scraper: weatherscraper,
+		},
+	)
+	weather, err := weatherrunner.Run()
+	assert.NoError(t, err)
+	// 10 games, 24 hourly weather readings each
+	assert.Equal(t, 240, len(weather), "240 weather records")
+
+	testRecord := weather[0]
+	assert.Equal(t, int64(822946), testRecord.EventID)
+	assert.Equal(t, time.Date(2026, time.July, 30, 16, 10, 0, 0, time.UTC), testRecord.EventTime)
+
+	assert.Equal(t, int64(139), testRecord.HomeTeamID)
+	assert.Equal(t, "TB", testRecord.HomeTeamAbbreviation)
+	assert.Equal(t, "Tampa Bay Rays", testRecord.HomeTeam)
+	assert.Equal(t, int64(140), testRecord.AwayTeamID)
+	assert.Equal(t, "TEX", testRecord.AwayTeamAbbreviation)
+	assert.Equal(t, "Texas Rangers", testRecord.AwayTeam)
+
+	assert.Equal(t, int64(12), testRecord.BallparkID)
+	assert.Equal(t, "Tropicana Field", testRecord.BallparkName)
+	assert.InDelta(t, float32(27.767778), testRecord.BallparkLatitude, 0.0001)
+	assert.InDelta(t, float32(-82.6525), testRecord.BallparkLongitude, 0.0001)
+	assert.Equal(t, float32(359), *testRecord.BallparkAzimuthAngle)
+	assert.Equal(t, int32(15), *testRecord.BallparkElevation)
+	assert.Equal(t, int32(25025), testRecord.BallparkCapacity)
+	assert.Equal(t, "Artificial Turf", testRecord.BallparkTurfType)
+	assert.Equal(t, "Dome", testRecord.BallparkRoofType)
+	assert.Equal(t, int32(315), testRecord.BallparkLeftLine)
+	assert.Equal(t, int32(370), *testRecord.BallparkLeft)
+	assert.Equal(t, int32(410), testRecord.BallparkLeftCenter)
+	assert.Equal(t, int32(404), testRecord.BallparkCenter)
+	assert.Equal(t, int32(404), testRecord.BallparkRightCenter)
+	assert.Equal(t, int32(370), *testRecord.BallparkRight)
+	assert.Equal(t, int32(322), testRecord.BallparkRightLine)
+	assert.Equal(t, int32(11), testRecord.BallparkFenceHeightLeft)
+	assert.Equal(t, int32(9), testRecord.BallparkFenceHeightCenter)
+	assert.Equal(t, int32(11), testRecord.BallparkFenceHeightRight)
+	assert.True(t, testRecord.BallparkActive)
+	assert.Equal(t, int32(2026), testRecord.BallparkSeason)
+
+	assert.Equal(t, time.Date(2026, time.July, 30, 4, 0, 0, 0, time.UTC), testRecord.WeatherDataDateTime)
+	assert.Equal(t, float32(83.9), testRecord.WeatherDataTemp)
+	assert.Equal(t, float32(95.7), testRecord.WeatherDataFeelsLike)
+	assert.Equal(t, float32(85.07), testRecord.WeatherDataHumidity)
+	assert.Equal(t, float32(78.9), testRecord.WeatherDataDew)
+	assert.Equal(t, float32(0), testRecord.WeatherDataPrecipitation)
+	assert.Equal(t, float32(0), testRecord.WeatherDataPrecipitationProbability)
+	assert.Equal(t, float32(0), testRecord.WeatherDataSnow)
+	assert.Equal(t, float32(0), testRecord.WeatherDataSnowDepth)
+	assert.Equal(t, float32(17.2), *testRecord.WeatherDataWindGust)
+	assert.Equal(t, float32(9), testRecord.WeatherDataWindSpeed)
+	assert.Equal(t, float32(259), testRecord.WeatherDataWindDir)
+	assert.Equal(t, float32(1014), testRecord.WeatherDataPressure)
+	assert.Equal(t, float32(9.9), testRecord.WeatherDataVisibility)
+	assert.Equal(t, float32(27), testRecord.WeatherDataCloudCover)
+	assert.Equal(t, float32(0), testRecord.WeatherDataSolarRadiation)
+	assert.Equal(t, float32(0), testRecord.WeatherDataSolarEnergy)
+	assert.Equal(t, float32(0), testRecord.WeatherDataUVIndex)
+	assert.Equal(t, float32(60), testRecord.WeatherDataSevereRisk)
+	assert.Equal(t, "Partially cloudy", testRecord.WeatherDataConditions)
+}
+
+// TestWeatherScraper_FractionalBallparkAzimuthAngle guards against a
+// regression where ballpark.azimuthAngle was assumed to always be a whole
+// number and typed int32; the API returns it as a float on some dates
+// (e.g. Angel Stadium was 43.61 on this date), which broke JSON unmarshaling.
+func TestWeatherScraper_FractionalBallparkAzimuthAngle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	weatherscraper := NewWeatherScraper(
+		WeatherScraperDate("2026-07-31"),
+	)
+	weatherrunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerConfig[model.Weather]{
+			Scraper: weatherscraper,
+		},
+	)
+	weather, err := weatherrunner.Run()
+	assert.NoError(t, err)
+
+	found := false
+	for _, w := range weather {
+		if w.EventID == 823999 {
+			found = true
+			assert.Equal(t, int64(1), w.BallparkID)
+			assert.Equal(t, "Angel Stadium", w.BallparkName)
+			assert.Equal(t, float32(43.61), *w.BallparkAzimuthAngle)
+			break
+		}
+	}
+	assert.True(t, found, "expected to find event_id 823999 (Angel Stadium, LAA vs MIL)")
+}
+
+// TestWeatherScraper_NullBallparkFields guards against a regression where
+// ballpark.left, ballpark.right, ballpark.azimuthAngle, and
+// ballpark.elevation were assumed to always be present and typed as plain
+// (non-pointer) fields; the API returns JSON null for these on many real
+// ballparks (a 10-date/126-game sample found null left/right on 23 distinct
+// ballparks including Yankee Stadium, Fenway Park, and Wrigley Field), which
+// silently unmarshaled to 0 instead of the actual "no data" state.
+func TestWeatherScraper_NullBallparkFields(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	weatherscraper := NewWeatherScraper(
+		WeatherScraperDate("2026-04-01"),
+	)
+	weatherrunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerConfig[model.Weather]{
+			Scraper: weatherscraper,
+		},
+	)
+	weather, err := weatherrunner.Run()
+	assert.NoError(t, err)
+
+	found := false
+	for _, w := range weather {
+		if w.EventID == 825106 {
+			found = true
+			assert.Equal(t, int64(15), w.BallparkID)
+			assert.Equal(t, "Chase Field", w.BallparkName)
+			assert.Nil(t, w.BallparkAzimuthAngle)
+			assert.NotNil(t, w.BallparkLeft)
+			assert.Equal(t, int32(374), *w.BallparkLeft)
+			assert.NotNil(t, w.BallparkRight)
+			assert.Equal(t, int32(374), *w.BallparkRight)
+			break
+		}
+	}
+	assert.True(t, found, "expected to find event_id 825106 (Chase Field)")
+}
+
+// TestWeatherScraper_NullWindGust guards against a regression where
+// weatherData.windGust was assumed to always be present and typed as a
+// plain (non-pointer) field; the API returned JSON null for it at least
+// once in the wild (Angel Stadium, LAA vs ATH, 2026-05-19), which silently
+// unmarshaled to 0 instead of reflecting "no data available".
+func TestWeatherScraper_NullWindGust(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	weatherscraper := NewWeatherScraper(
+		WeatherScraperDate("2026-05-19"),
+	)
+	weatherrunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerConfig[model.Weather]{
+			Scraper: weatherscraper,
+		},
+	)
+	weather, err := weatherrunner.Run()
+	assert.NoError(t, err)
+
+	found := false
+	for _, w := range weather {
+		if w.EventID == 824033 && w.WeatherDataDateTime.Equal(time.Date(2026, time.May, 19, 9, 0, 0, 0, time.UTC)) {
+			found = true
+			assert.Equal(t, int64(1), w.BallparkID)
+			assert.Equal(t, "Angel Stadium", w.BallparkName)
+			assert.Nil(t, w.WeatherDataWindGust)
+			assert.Equal(t, float32(60.9), w.WeatherDataTemp)
+			break
+		}
+	}
+	assert.True(t, found, "expected to find event_id 824033 (Angel Stadium, LAA vs ATH) weather reading at 2026-05-19T09:00:00Z")
+}
+
+func TestWeatherScraper_OffDay(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping integration test")
+	}
+	weatherscraper := NewWeatherScraper(
+		WeatherScraperDate("2026-01-15"),
+	)
+	weatherrunner := runner.NewMatchupRunner(
+		runner.MatchupRunnerConfig[model.Weather]{
+			Scraper: weatherscraper,
+		},
+	)
+	weather, err := weatherrunner.Run()
+	assert.NoError(t, err)
+	assert.Empty(t, weather, "no MLB games expected in mid-January")
+}

--- a/dataprovider/propfinder/mlb/url.go
+++ b/dataprovider/propfinder/mlb/url.go
@@ -1,0 +1,20 @@
+package mlb
+
+import (
+	"github.com/lightning-dabbler/sportscrape/util"
+)
+
+const (
+	URL = "https://api.propfinder.app"
+)
+
+// ConstructWeatherURL
+// https://api.propfinder.app/mlb/weather-games?date=2026-07-30
+func ConstructWeatherURL(date string) (string, error) {
+	timestamp, err := util.DateStrToTime(date)
+	if err != nil {
+		return "", err
+	}
+	datestr := timestamp.Format("2006-01-02")
+	return URL + "/mlb/weather-games?date=" + datestr, nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -2,4 +2,4 @@ package version
 
 // Version is a manually maintained semver version.
 // This is updated by hand when releasing new versions
-const Version = "v1.2.0"
+const Version = "v1.3.0"


### PR DESCRIPTION
### Added
- `propfinder` data provider (`dataprovider/propfinder/mlb`) — MLB weather-by-game data from `api.propfinder.app`, flattening each game's hourly weather readings into one row per reading (composite key: `event_id`, `ballpark_id`, `weather_data_date_time`). Wired into the CLI as `sportscrape propfinder mlb --feed weather` (#143)

### Changed
- Replaced the separate `go-lint` CI job (curl-installed `golangci-lint` v1.64.5) with a `golangci-lint` pre-commit hook (`github.com/golangci/golangci-lint` rev `v2.8.0` — the latest release still on `go 1.24.0`, matching this project's `go.mod`; `v2.9.0`+ require Go 1.25) run as part of the existing `pre-commit` job in `validate.yml`; removes the duplicate Go lint pass and its own CI job/output (#142)
- Bumped `pre-commit/pre-commit-hooks` rev `v5.0.0` → `v6.0.0` and `rhysd/actionlint` rev `v1.7.7` → `v1.7.10` in `.pre-commit-config.yaml` (#142)
- Bumped GitHub Actions across all workflows: `actions/checkout` `v6.0.2` → `v7.0.1`, `actions/setup-python` `v6.2.0` → `v7.0.0` (Python 3.11 → 3.13), `actions/setup-go` `v6.2.0` → `v6.5.0`, `actions/upload-artifact` `v4` → `v7.0.1` (`all-tests.yml`, `unit-tests.yml`), `actions/download-artifact` `v7.0.0` → `v8.0.1` (#142)
- Pinned `pre-commit` to `4.5.1` in `validate.yml` (was unpinned) (#142)

### Removed
- `successful_go_lint_run` output from `validate.yml` and its reference in `deploy.yml`'s approval gate, now redundant with `golangci-lint` running via pre-commit (#142)